### PR TITLE
カテゴリーページのレイアウトを調整した

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -35,7 +35,6 @@ class CategoriesController < ApplicationController
   def destroy
     @category.destroy
     flash.now.notice = t('notice.destroy.category')
-    # redirect_to categories_path, notice: t('notice.destroy.category')
   end
 
   def destroy_with_memories

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -6,7 +6,6 @@ class CategoriesController < ApplicationController
   def index
     @q = current_user.categories.ransack(params[:q])
     @q.sorts = 'id desc' if @q.sorts.blank?
-
     @categories = @q.result.page(params[:page])
   end
 

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -34,7 +34,8 @@ class CategoriesController < ApplicationController
 
   def destroy
     @category.destroy
-    redirect_to categories_path, notice: t('notice.destroy.category')
+    flash.now.notice = t('notice.destroy.category')
+    # redirect_to categories_path, notice: t('notice.destroy.category')
   end
 
   def destroy_with_memories

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -4,9 +4,9 @@ class Category < ApplicationRecord
   belongs_to :user
   has_many :memories, dependent: :nullify
 
-  validates :name, presence: true, length: { maximum: 24 }, uniqueness: { scope: :user_id }
+  validates :name, presence: true, length: { maximum: 20 }, uniqueness: { scope: :user_id }
 
-  paginates_per 5
+  paginates_per 15
 
   def self.ransackable_attributes(_auth_object = nil)
     ['id']

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -6,7 +6,7 @@ class Memory < ApplicationRecord
 
   validates :content, presence: true, length: { maximum: 400 }
 
-  paginates_per 10
+  paginates_per 15
 
   def self.ransackable_attributes(_auth_object = nil)
     ['id']

--- a/app/views/categories/_form.html.slim
+++ b/app/views/categories/_form.html.slim
@@ -1,0 +1,18 @@
+.text-center.w-full
+  span data-controller="modal"
+    i.fa-regular.fa-circle-question.ml-2.text-gray-500.hover:text-gray-900.cursor-pointer.text-sm.md:text-base.mb-8 data-action="click->modal#open"
+      | カテゴリーについてもっと詳しく見る
+    .hidden.fixed.w-full.h-screen.top-0.left-0.bg-gray-700/50.z-20.font-normal data-modal-target="modal" data-action="click->modal#close"
+      .absolute.top-0.md:top-1/2.left-1/2.-translate-x-1/2.md:-translate-y-1/2.bg-white.rounded-md.w-full.md:max-w-md data-action="click->modal#stay"
+        = render 'layouts/category_description'
+  = form_with(model: category, local: true, class: 'w-full') do |form|
+    - if category.errors.any?
+      ul.flex.flex-col.items-center
+        - category.errors.full_messages.each do |message|
+          li.text-red-500.font-normal.text-sm.md:text-base.mb-2.block = message
+    .w-full.max-w-2xl.mx-auto.px-4.justify-center.mb-8
+      = form.text_field :name, class: 'w-full md:w-3/5 text-base font-normal mx-auto px-2 text-center md:text-lg'
+    .flex.justify-center.mt-10.mb-4.text-sm.md:text-base
+      = form.submit '保存する', class: 'bg-sky-300 hover:bg-sky-500 text-white font-bold py-2 rounded w-36 md:w-44'
+    .flex.justify-center.mt-10.mb-4.text-sm.md:text-base
+      = link_to '戻る', categories_path, class: 'text-gray-500 hover:text-gray-900 underline'

--- a/app/views/categories/destroy.turbo_stream.slim
+++ b/app/views/categories/destroy.turbo_stream.slim
@@ -1,2 +1,2 @@
 = turbo_stream.remove @category
-= turbo_stream.update "flash", partial: 'layouts/flash'
+= turbo_stream.update 'flash', partial: 'layouts/flash'

--- a/app/views/categories/destroy.turbo_stream.slim
+++ b/app/views/categories/destroy.turbo_stream.slim
@@ -1,0 +1,2 @@
+= turbo_stream.remove @category
+= turbo_stream.update "flash", partial: 'layouts/flash'

--- a/app/views/categories/edit.html.slim
+++ b/app/views/categories/edit.html.slim
@@ -1,12 +1,6 @@
-/ 後ほどモーダル化する
-h1.text-xl.font-bold.text-center
+h1.text-2xl.font-bold.text-center.text-gray-600.mt-8
   | カテゴリーの編集
-  p.text-sm.font-normal.mt-10.mb-8.w-full
-    | 以下に変更したいカテゴリー名を入力してください。（最大24文字）
-    .w-full.max-w-2xl.mx-auto.px-4.md:px-24
-    = form_with(model: @category, local: true) do |form|
-      = form.text_field :name, class: 'w-full text-sm font-normal max-w-2xl mx-auto px-4 text-center md:px-24 md:text-base'
-      .flex.justify-center.mt-10.mb-4.text-sm.md:text-base
-        = form.submit '保存する', class: 'bg-sky-300 hover:bg-sky-400 text-white font-bold py-2 px-4 rounded'
-      .flex.justify-center.text-sm.md:text-base
-        = link_to '戻る', categories_path, class: 'bg-sky-300 hover:bg-sky-400 text-white font-bold py-2 px-4 rounded'
+  p.text-sm.md:text-base.font-normal.mt-10.mb-2
+    | 以下に変更したいカテゴリー名を入力してください。（最大20文字）
+
+    = render 'form', category: @category

--- a/app/views/categories/index.html.slim
+++ b/app/views/categories/index.html.slim
@@ -16,7 +16,7 @@ h1.text-2xl.font-bold.text-center.text-gray-600.mt-8
   .text-lg.font-normal.text-gray-500.mt-6.mb-12.underline.underline-offset-1
     = sort_link(@q, :id, '投稿順')
   = turbo_frame_tag "categories-page-#{@categories.current_page}" do
-    - if Category.exists?
+    - if @categories.exists?
       - @categories.each do |category|
         .w-full.max-w-4xl.mx-auto
           .flex.flex-wrap.md:flex-nowrap.items-center.justify-center.font-normal.mt-5
@@ -28,6 +28,6 @@ h1.text-2xl.font-bold.text-center.text-gray-600.mt-8
               category, method: :delete, data: { turbo_confirm: sanitize("カテゴリー「#{category.name}」を削除しますか？\n紐づけられている#{category.memories.count}件の思い出は「カテゴリー登録なし」になります。") }, class: 'bg-gray-400 hover:bg-gray-500 text-white font-bold py-2 w-36 md:w-44 rounded'
     - else
       .text-center.m-5.font-normal.text-base
-        | カテゴリーがありません。
+        | カテゴリーがまだ登録されていません。
 
     = turbo_frame_tag "categories-page-#{@categories.next_page}", loading: :lazy, src: path_to_next_page(@categories)

--- a/app/views/categories/index.html.slim
+++ b/app/views/categories/index.html.slim
@@ -18,14 +18,15 @@ h1.text-2xl.font-bold.text-center.text-gray-600.mt-8
   = turbo_frame_tag "categories-page-#{@categories.current_page}" do
     - if @categories.exists?
       - @categories.each do |category|
-        .w-full.max-w-4xl.mx-auto
-          .flex.flex-wrap.md:flex-nowrap.items-center.justify-center.font-normal.mt-5
-            .w-full.underline.underline-offset-1.text-center.text-base.md:text-lg.mb-4.hover:text-gray-900
-              = link_to "#{category.name}(#{category.memories.count}件)", category_memories_path(category.id), data: { turbo: false }
-          .flex.flex-row.justify-center.items-center.space-y-2.space-y-0.space-x-12.md:space-x-16.text-sm.md:text-base.md:mb-10.mt-6.mb-6
-            = link_to t('activerecord.action.edit'), edit_category_path(category), data: { turbo: false }, class: 'bg-sky-300 hover:bg-sky-500 text-white font-bold py-2 rounded w-36 md:w-44'
-            = button_to t('activerecord.action.destroy.category'),
-              category, method: :delete, data: { turbo_confirm: sanitize("カテゴリー「#{category.name}」を削除しますか？\n紐づけられている#{category.memories.count}件の思い出は「カテゴリー登録なし」になります。") }, class: 'bg-gray-400 hover:bg-gray-500 text-white font-bold py-2 w-36 md:w-44 rounded'
+        = turbo_frame_tag category do
+          .w-full.max-w-4xl.mx-auto
+            .flex.flex-wrap.md:flex-nowrap.items-center.justify-center.font-normal.mt-5
+              .w-full.underline.underline-offset-1.text-center.text-base.md:text-lg.mb-4.hover:text-gray-900
+                = link_to "#{category.name}(#{category.memories.count}件)", category_memories_path(category.id), data: { turbo: false }
+            .flex.flex-row.justify-center.items-center.space-y-2.space-y-0.space-x-12.md:space-x-16.text-sm.md:text-base.md:mb-10.mt-6.mb-6
+              = link_to t('activerecord.action.edit'), edit_category_path(category), data: { turbo: false }, class: 'bg-sky-300 hover:bg-sky-500 text-white font-bold py-2 rounded w-36 md:w-44'
+              = button_to t('activerecord.action.destroy.category'),
+                category, method: :delete, data: { turbo_confirm: sanitize("カテゴリー「#{category.name}」を削除しますか？\n紐づけられている#{category.memories.count}件の思い出は「カテゴリー登録なし」になります。") }, class: 'bg-gray-400 hover:bg-gray-500 text-white font-bold py-2 w-36 md:w-44 rounded'
     - else
       .text-center.m-5.font-normal.text-base
         | カテゴリーがまだ登録されていません。

--- a/app/views/categories/index.html.slim
+++ b/app/views/categories/index.html.slim
@@ -26,7 +26,8 @@ h1.text-2xl.font-bold.text-center.text-gray-600.mt-8
             .flex.flex-row.justify-center.items-center.space-y-2.space-y-0.space-x-12.md:space-x-16.text-sm.md:text-base.md:mb-10.mt-6.mb-6
               = link_to t('activerecord.action.edit'), edit_category_path(category), data: { turbo: false }, class: 'bg-sky-300 hover:bg-sky-500 text-white font-bold py-2 rounded w-36 md:w-44'
               = button_to t('activerecord.action.destroy.category'),
-                category, method: :delete, data: { turbo_confirm: sanitize("カテゴリー「#{category.name}」を削除しますか？\n紐づけられている#{category.memories.count}件の思い出は「カテゴリー登録なし」になります。") }, class: 'bg-gray-400 hover:bg-gray-500 text-white font-bold py-2 w-36 md:w-44 rounded'
+                category, method: :delete, data: { turbo_confirm: sanitize("カテゴリー「#{category.name}」を削除しますか？\n紐づけられている#{category.memories.count}件の思い出は「カテゴリー登録なし」になります。") },
+                class: 'bg-gray-400 hover:bg-gray-500 text-white font-bold py-2 w-36 md:w-44 rounded'
     - else
       .text-center.m-5.font-normal.text-base
         | カテゴリーがまだ登録されていません。

--- a/app/views/categories/index.html.slim
+++ b/app/views/categories/index.html.slim
@@ -1,32 +1,33 @@
-h1.text-xl.font-bold.text-center.mt-8
+h1.text-2xl.font-bold.text-center.text-gray-600.mt-8
   | カテゴリーの一覧
-  p.text-sm.font-normal.mt-10.mb-8
-   | このページではカテゴリー名の編集や削除ができます。
-  .text-sm.font-normal.mt-3.mb-8
+  i.fa-solid.fa-bookmark.m-2
+  p.text-sm.md:text-base.font-normal.mt-10.mb-8
+   | カテゴリーの登録、編集、削除ができます。
+  .text-sm.md:text-base.font-normal.mt-3.mb-8
    span data-controller="modal"
         i.fa-regular.fa-circle-question.ml-2.text-gray-500.hover:text-gray-900.cursor-pointer data-action="click->modal#open"
           | カテゴリーについてもっと詳しく見る
         .hidden.fixed.w-full.h-screen.top-0.left-0.bg-gray-700/50.z-20 data-modal-target="modal" data-action="click->modal#close"
           .absolute.top-0.md:top-1/2.left-1/2.-translate-x-1/2.md:-translate-y-1/2.bg-white.rounded-md.w-full.md:max-w-md data-action="click->modal#stay"
             = render 'layouts/category_description'
+  .font-normal.text-sm.mb-8
+    = link_to '＋カテゴリーを登録する', new_category_path, class: 'text-lg bg-sky-300 hover:bg-sky-400 text-white font-bold py-3 px-5 rounded'
 
-  .text-sm.font-normal.text-gray-500.mt-3.mb-8.underline.underline-offset-1
+  .text-lg.font-normal.text-gray-500.mt-6.mb-12.underline.underline-offset-1
     = sort_link(@q, :id, '投稿順')
-  - if Category.exists?
-    - @categories.each do |category|
-      .w-full.max-w-4xl.mx-auto
-        .flex.flex-wrap.md:flex-nowrap.items-center.justify-center.font-normal.mt-5
-          .w-full.underline.underline-offset-1.text-center.text-sm.md:text-base.mb-4
-            = link_to "#{category.name}(#{category.memories.count}件)", category_memories_path(category.id)
-        .flex.justify-center.items-center.space-x-4.text-xs.md:text-sm.mb-12
-          = button_to t('activerecord.action.edit'), edit_category_path(category), method: :get, class: 'bg-sky-300 hover:bg-sky-400 text-white font-bold py-2 px-3 rounded'
-          = button_to t('activerecord.action.destroy.category'),
-            category, method: :delete, data: { turbo_confirm: sanitize("カテゴリー「#{category.name}」を削除しますか？\n紐づけられている#{category.memories.count}件の思い出は「カテゴリー登録なし」になります。") }, class: 'bg-sky-300 hover:bg-sky-400 text-white font-bold py-2 px-3 rounded'
-  - else
-    .text-center.m-5.font-normal.text-base
-      | カテゴリーがありません。
+  = turbo_frame_tag "categories-page-#{@categories.current_page}" do
+    - if Category.exists?
+      - @categories.each do |category|
+        .w-full.max-w-4xl.mx-auto
+          .flex.flex-wrap.md:flex-nowrap.items-center.justify-center.font-normal.mt-5
+            .w-full.underline.underline-offset-1.text-center.text-sm.md:text-base.mb-4.hover:text-gray-900
+              = link_to "#{category.name}(#{category.memories.count}件)", category_memories_path(category.id)
+          .flex.flex-row.justify-center.items-center.space-y-2.space-y-0.space-x-12.md:space-x-16.text-sm.md:text-base.md:mb-10.mt-6.mb-6
+            = button_to t('activerecord.action.edit'), edit_category_path(category), method: :get, class: 'bg-sky-300 hover:bg-sky-500 text-white font-bold py-2 rounded w-36 md:w-44'
+            = button_to t('activerecord.action.destroy.category'),
+              category, method: :delete, data: { turbo_confirm: sanitize("カテゴリー「#{category.name}」を削除しますか？\n紐づけられている#{category.memories.count}件の思い出は「カテゴリー登録なし」になります。") }, class: 'bg-gray-400 hover:bg-gray-500 text-white font-bold py-2 w-36 md:w-44 rounded'
+    - else
+      .text-center.m-5.font-normal.text-base
+        | カテゴリーがありません。
 
-  = paginate @categories
-
-  .font-normal.text-sm.mt-20
-    = link_to 'カテゴリーを登録する', new_category_path, class: 'text-lg bg-sky-300 hover:bg-sky-400 text-white font-bold py-3 px-5 rounded'
+    = turbo_frame_tag "categories-page-#{@categories.next_page}", loading: :lazy, src: path_to_next_page(@categories)

--- a/app/views/categories/index.html.slim
+++ b/app/views/categories/index.html.slim
@@ -13,17 +13,17 @@ h1.text-2xl.font-bold.text-center.text-gray-600.mt-8
   .font-normal.text-sm.mb-8
     = link_to '＋カテゴリーを登録する', new_category_path, class: 'text-lg bg-sky-300 hover:bg-sky-400 text-white font-bold py-3 px-5 rounded'
 
-  .text-lg.font-normal.text-gray-500.mt-6.mb-12.underline.underline-offset-1
+  .text-base.md:text-lg.font-normal.text-gray-500.mt-6.mb-12.underline.underline-offset-1
     = sort_link(@q, :id, '投稿順')
   = turbo_frame_tag "categories-page-#{@categories.current_page}" do
     - if @categories.exists?
       - @categories.each do |category|
         .w-full.max-w-4xl.mx-auto
           .flex.flex-wrap.md:flex-nowrap.items-center.justify-center.font-normal.mt-5
-            .w-full.underline.underline-offset-1.text-center.text-sm.md:text-base.mb-4.hover:text-gray-900
-              = link_to "#{category.name}(#{category.memories.count}件)", category_memories_path(category.id)
+            .w-full.underline.underline-offset-1.text-center.text-base.md:text-lg.mb-4.hover:text-gray-900
+              = link_to "#{category.name}(#{category.memories.count}件)", category_memories_path(category.id), data: { turbo: false }
           .flex.flex-row.justify-center.items-center.space-y-2.space-y-0.space-x-12.md:space-x-16.text-sm.md:text-base.md:mb-10.mt-6.mb-6
-            = button_to t('activerecord.action.edit'), edit_category_path(category), method: :get, class: 'bg-sky-300 hover:bg-sky-500 text-white font-bold py-2 rounded w-36 md:w-44'
+            = link_to t('activerecord.action.edit'), edit_category_path(category), data: { turbo: false }, class: 'bg-sky-300 hover:bg-sky-500 text-white font-bold py-2 rounded w-36 md:w-44'
             = button_to t('activerecord.action.destroy.category'),
               category, method: :delete, data: { turbo_confirm: sanitize("カテゴリー「#{category.name}」を削除しますか？\n紐づけられている#{category.memories.count}件の思い出は「カテゴリー登録なし」になります。") }, class: 'bg-gray-400 hover:bg-gray-500 text-white font-bold py-2 w-36 md:w-44 rounded'
     - else

--- a/app/views/categories/index.html.slim
+++ b/app/views/categories/index.html.slim
@@ -2,9 +2,13 @@ h1.text-xl.font-bold.text-center.mt-8
   | カテゴリーの一覧
   p.text-sm.font-normal.mt-10.mb-8
    | このページではカテゴリー名の編集や削除ができます。
-  p.text-sm.font-normal.mt-3.mb-8
-    / TODO:はてなアイコンを追加する
-    | '?'カテゴリーについてもっと詳しく知る
+  .text-sm.font-normal.mt-3.mb-8
+   span data-controller="modal"
+        i.fa-regular.fa-circle-question.ml-2.text-gray-500.hover:text-gray-900.cursor-pointer data-action="click->modal#open"
+          | カテゴリーについてもっと詳しく見る
+        .hidden.fixed.w-full.h-screen.top-0.left-0.bg-gray-700/50.z-20 data-modal-target="modal" data-action="click->modal#close"
+          .absolute.top-0.md:top-1/2.left-1/2.-translate-x-1/2.md:-translate-y-1/2.bg-white.rounded-md.w-full.md:max-w-md data-action="click->modal#stay"
+            = render 'layouts/category_description'
 
   .text-sm.font-normal.text-gray-500.mt-3.mb-8.underline.underline-offset-1
     = sort_link(@q, :id, '投稿順')

--- a/app/views/categories/new.html.slim
+++ b/app/views/categories/new.html.slim
@@ -1,17 +1,6 @@
-/ 後ほどモーダル化する
-h1.font-bold.mb-10.text-xl.text-center
+h1.text-2xl.font-bold.text-center.text-gray-600.mt-8
   | カテゴリーの新規登録
-  p.text-sm.font-normal.mt-3.mb-8
+  p.text-sm.md:text-base.font-normal.mt-10.mb-2
     | 新しく登録するカテゴリー名を入力してください。（最大20文字）
-    - if @category.errors.any?
-        ul.flex.flex-col.items-start
-          - @category.errors.full_messages.each do |message|
-            li.text-red-500.font-normal.text-sm.block = message
 
-  .flex.justify-center
-    = form_with(model: @category, local: true) do |form|
-      = form.label :name, Category.human_attribute_name(:name)
-        = form.text_field :name, class: 'w-80'
-        .flex.justify-between.mt-4.space-x-2
-          = form.submit '保存する', class: 'bg-sky-300 hover:bg-sky-400 text-white font-bold py-2 px-4 rounded'
-          = link_to '戻る', categories_path, class: 'bg-sky-300 hover:bg-sky-400 text-white font-bold py-2 px-4 rounded'
+    = render 'form', category: @category

--- a/app/views/categories/new.html.slim
+++ b/app/views/categories/new.html.slim
@@ -2,7 +2,7 @@
 h1.font-bold.mb-10.text-xl.text-center
   | カテゴリーの新規登録
   p.text-sm.font-normal.mt-3.mb-8
-    | 新しく登録するカテゴリー名を入力してください。（最大24文字）
+    | 新しく登録するカテゴリー名を入力してください。（最大20文字）
     - if @category.errors.any?
         ul.flex.flex-col.items-start
           - @category.errors.full_messages.each do |message|

--- a/app/views/layouts/_flash.html.slim
+++ b/app/views/layouts/_flash.html.slim
@@ -1,28 +1,28 @@
 div data-controller="removal"
   - if flash[:after_destroy]
-    .w-full.bg-cyan-100.border-cyan-500.text-cyan-700.pt-0.pb-0.h-10.flex.justify-between.items-center.pl-2.md:pl-32.md:h-14
+    .w-full.bg-cyan-100.border-cyan-500.text-cyan-700.pt-0.pb-0.h-10.flex.justify-between.items-center.pl-2.md:pl-8.md:h-14
       .flex.items-center
-        = image_tag 'flying_bird.png', alt: '飛び立つ鳥', class: 'w-32 h-21 md:mr-4'
+        = image_tag 'flying_bird.png', alt: '飛び立つ鳥', class: 'w-32 h-21'
         = flash[:after_destroy]
       p.text-xl.text-gray-500.hover:text-gray-900.ml-auto.cursor-pointer.px-4.py-3 data-action='click->removal#remove'
         | ×
   - if flash[:after_create]
-    .w-full.bg-cyan-100.border-cyan-500.text-cyan-700.pt-2.pb-2.h-10.flex.justify-between.items-center.pl-16.md:pl-32.md:h-14
+    .w-full.bg-cyan-100.border-cyan-500.text-cyan-700.pt-2.pb-2.h-10.flex.justify-between.items-center.pl-8.md:pl-16.md:h-14
       span.flex.items-center.text-sm.md:text-base
         == flash[:after_create]
       p.text-xl.text-gray-500.hover:text-gray-900.ml-auto.cursor-pointer.px-4.py-3 data-action='click->removal#remove'
         | ×
   - if flash[:after_create_with_link]
-    .w-full.bg-cyan-100.border-cyan-500.text-cyan-700.pb-2.h-6.flex.justify-between.items-center.pl-16.md:pl-32.md:h-8
+    .w-full.bg-cyan-100.border-cyan-500.text-cyan-700.pb-2.h-6.flex.justify-between.items-center.pl-8.md:pl-16.md:h-8
       span.flex.items-center.underline.hover:text-gray-900.text-sm.md:text-base
         == flash[:after_create_with_link]
   - if notice
-    .w-full.bg-cyan-100.border-cyan-500.text-cyan-700.pt-0.pb-0.h-10.flex.justify-between.items-center.pl-16.md:pl-32.md:h-14
+    .w-full.bg-cyan-100.border-cyan-500.text-cyan-700.pt-0.pb-0.h-10.flex.justify-between.items-center.pl-8.md:pl-16.md:h-14
       = notice
       p.text-xl.text-gray-500.hover:text-gray-900.ml-auto.cursor-pointer.px-4.py-3 data-action='click->removal#remove'
         | ×
   - if alert
-    .w-full.bg-cyan-100.border-cyan-500.text-cyan-700.pt-0.pb-0.h-10.flex.justify-between.items-center.pl-16.md:pl-32.md:h-14
+    .w-full.bg-cyan-100.border-cyan-500.text-cyan-700.pt-0.pb-0.h-10.flex.justify-between.items-center.pl-8.md:pl-16.md:h-14
       = alert
       p.text-xl.text-gray-500.hover:text-gray-900.ml-auto.cursor-pointer.px-4.py-3 data-action='click->removal#remove'
         | ×

--- a/db/migrate/20240716105411_change_length_constraint_to_name_in_categories.rb
+++ b/db/migrate/20240716105411_change_length_constraint_to_name_in_categories.rb
@@ -1,0 +1,5 @@
+class ChangeLengthConstraintToNameInCategories < ActiveRecord::Migration[7.1]
+  def change
+    change_column :categories, :name, :string, limit: 20
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_19_040243) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_16_105411) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "categories", force: :cascade do |t|
-    t.string "name", limit: 24, null: false
+    t.string "name", limit: 20, null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
## Issue
- #124 

## 概要
- カテゴリー登録/編集ページにカテゴリー説明のモーダルを追加
- カテゴリー一覧ページに無限スクロールの実装
- カテゴリー関連のページのレイアウトを調整
- カテゴリーの削除をTurbo Stream化