### PR TITLE
思い出登録時にコンテンツが空白だった時の処理を追加、思い出関連のレイアウトを調整

### DIFF
--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -27,6 +27,7 @@ class MemoriesController < ApplicationController
       flash.now[:after_create_with_link] = view_context.link_to('（思い出の一覧を見る）', memories_path) unless request.referer.include?(memories_path)
     else
       set_categories
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/views/memories/_form.html.slim
+++ b/app/views/memories/_form.html.slim
@@ -3,7 +3,7 @@
     - if memory.errors.any?
       ul.flex.flex-col.items-center
         - memory.errors.full_messages.each do |message|
-          li.text-red-500.font-normal.text-sm.block = message
+          li.text-red-500.font-normal.text-sm.md:text-base.mb-2.block = message
     .w-full.max-w-2xl.mx-auto.px-4.justify-center.mb-8
       = form.text_area :content, class: 'w-full h-48 font-normal md:h-72'
     p.text-sm.font-normal.mb-4.text-gray-600.text-center.md:text-base

--- a/app/views/memories/_memory.html.slim
+++ b/app/views/memories/_memory.html.slim
@@ -1,5 +1,5 @@
 = turbo_frame_tag memory do
-  .w-full.max-w-2xl.mx-auto.px-2.font-normal.md:px-24.text-black
+  .w-full.max-w-2xl.mx-auto.px-2.font-normal.md:px-10.text-black
     .flex.flex-col.items-center.justify-center.text-base.md:text-lg.mt-5
       p
         = simple_format memory.content, class: 'text-left'

--- a/app/views/memories/index.html.slim
+++ b/app/views/memories/index.html.slim
@@ -1,7 +1,7 @@
 h1.text-2xl.font-bold.text-center.text-gray-600.mt-8
   | 思い出の一覧
   i.fa-solid.fa-book.m-2
-  .text-lg.font-normal.text-gray-500.mt-6.mb-12.underline.underline-offset-1
+  .text-base.md:text-lg.font-normal.text-gray-500.mt-6.mb-12.underline.underline-offset-1
     = sort_link(@q, :id, '投稿順')
 
   = turbo_frame_tag "memories-page-#{@memories.current_page}" do
@@ -10,9 +10,13 @@ h1.text-2xl.font-bold.text-center.text-gray-600.mt-8
         = turbo_frame_tag 'memories'
           = render memory
     - else
-      .text-center.m-5.font-normal.text-base
+      .text-center.m-5.font-normal.text-base.md:text-lg
         | 思い出がまだ登録されていません。
         br
-        | 画面右下の✏️ボタンをクリックし、思い出を登録してみましょう。
+        | 画面右下の
+        i.fa-solid.fa-pen-to-square
+        | ボタンをクリックして
+        br
+        | 思い出を登録してみましょう。
 
     = turbo_frame_tag "memories-page-#{@memories.next_page}", loading: :lazy, src: path_to_next_page(@memories)


### PR DESCRIPTION
## Issue
- #130 

## 概要
- 思い出登録時に保存に失敗した際にエラーが出てしまうバグの修正
- エラーメッセージ/文字サイズ/アイコンの追加等、思い出関連の軽微なレイアウト修正
