### PR TITLE
カテゴリーを思い出と同時に登録できるようにした

### DIFF
--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -2,7 +2,8 @@
 
 class MemoriesController < ApplicationController
   before_action :set_memory, only: %i[edit update destroy]
-  before_action :set_categories, only: %i[new edit]
+  before_action :set_categories, only: %i[new edit create]
+  before_action :initialize_category_errors, only: %i[new create edit update]
 
   def random
     @memory = current_user.memories.order('RANDOM()').first
@@ -22,12 +23,16 @@ class MemoriesController < ApplicationController
 
   def create
     @memory = current_user.memories.build(memory_params)
-    if @memory.save
-      if request.referer.include?(memories_path)
-        flash.now[:after_create] = t('notice.create.memory')
-      else
-        flash.now[:after_create_with_link] = view_context.link_to('思い出を記録しました。（思い出の一覧を見る）', memories_path) unless request.referer.include?(memories_path)
-      end
+
+    if params[:memory][:new_category_name].present?
+      validate_and_set_category
+    elsif params[:memory][:category_id].present?
+      set_existing_category
+    end
+
+    if @memory.valid? && valid_category?
+      @memory.save
+      display_appropriate_flash_messages
     else
       set_categories
       render :new, status: :unprocessable_entity
@@ -58,7 +63,33 @@ class MemoriesController < ApplicationController
     @categories = current_user.categories.all
   end
 
+  def initialize_category_errors
+    @category_errors = []
+  end
+
   def memory_params
     params.require(:memory).permit(:content, :category_id)
+  end
+
+  def validate_and_set_category
+    @category = current_user.categories.find_or_initialize_by(name: params[:memory][:new_category_name])
+    @category.errors.full_messages.each { |msg| @category_errors << msg } unless @category.valid?
+    @memory.category = @category
+  end
+
+  def set_existing_category
+    @memory.category = current_user.categories.find(params[:memory][:category_id])
+  end
+
+  def valid_category?
+    @memory.category.nil? || @memory.category&.valid?
+  end
+
+  def display_appropriate_flash_messages
+    if request.referer.include?(memories_path)
+      flash.now[:after_create] = t('notice.create.memory')
+    else
+      flash.now[:after_create_with_link] = view_context.link_to('思い出を記録しました。（思い出の一覧を見る）', memories_path) unless request.referer.include?(memories_path)
+    end
   end
 end

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -28,8 +28,6 @@ class MemoriesController < ApplicationController
       else
         flash.now[:after_create_with_link] = view_context.link_to('思い出を記録しました。（思い出の一覧を見る）', memories_path) unless request.referer.include?(memories_path)
       end
-      # flash.now[:after_create] = t('notice.create.memory')
-      # flash.now[:after_create_with_link] = view_context.link_to('（思い出の一覧を見る）', memories_path) unless request.referer.include?(memories_path)
     else
       set_categories
       render :new, status: :unprocessable_entity

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -2,7 +2,7 @@
 
 class MemoriesController < ApplicationController
   before_action :set_memory, only: %i[edit update destroy]
-  before_action :set_categories, only: %i[new edit create]
+  before_action :set_categories, only: %i[new create edit update]
   before_action :initialize_category_errors, only: %i[new create edit update]
 
   def random
@@ -40,7 +40,17 @@ class MemoriesController < ApplicationController
   end
 
   def update
-    if @memory.update(memory_params)
+    if params[:memory][:new_category_name].present?
+      validate_and_set_category
+    elsif params[:memory][:category_id].present?
+      set_existing_category
+    end
+
+    @memory.assign_attributes(memory_params)
+    @memory.category = @category if @category.present?
+
+    if @memory.valid? && valid_category?
+      @memory.save
       flash.now.notice = t('notice.update', model: Memory.model_name.human)
     else
       set_categories

--- a/app/views/memories/_form.html.slim
+++ b/app/views/memories/_form.html.slim
@@ -1,13 +1,18 @@
 = turbo_frame_tag memory do
   = form_with(model: memory, local: true, class: 'w-full') do |form|
-    - if memory.errors.any?
+    - if @memory.errors.any? || @category_errors.any?
       ul.flex.flex-col.items-center
         - memory.errors.full_messages.each do |message|
+          li.text-red-500.font-normal.text-sm.md:text-base.mb-2.block = message
+        - @category_errors.each do |message|
           li.text-red-500.font-normal.text-sm.md:text-base.mb-2.block = message
     .w-full.max-w-2xl.mx-auto.px-4.justify-center.mb-8
       = form.text_area :content, class: 'w-full h-48 font-normal md:h-72'
     p.text-sm.font-normal.mb-4.text-gray-600.text-center.md:text-base
-      | 思い出に紐づけるカテゴリーを登録しましょう。
+      | 思い出に紐づけるカテゴリーを選択、
+      br
+      | または新しいカテゴリーを登録しましょう。
+
     .text-center.w-full
       span data-controller="modal"
         i.fa-regular.fa-circle-question.ml-2.text-gray-500.hover:text-gray-900.cursor-pointer data-action="click->modal#open"
@@ -15,14 +20,15 @@
         .hidden.fixed.w-full.h-screen.top-0.left-0.bg-gray-700/50 data-modal-target="modal" data-action="click->modal#close"
           .absolute.top-0.md:top-1/2.left-1/2.-translate-x-1/2.md:-translate-y-1/2.bg-white.rounded-md.w-full.md:max-w-md data-action="click->modal#stay"
             = render 'layouts/category_description'
-      - if @categories.exists?
-        .flex.flex-col.w-full.mx-auto.px-4.justify-center.mb-8.mt-4.text-center
-          = form.label :category_id, 'カテゴリーを選択してください', class: 'mt-4 font-normal text-sm md:text-base'
-          = form.collection_select :category_id, @categories, :id, :name, { include_blank: 'カテゴリーなし' }, { class: 'font-normal mt-2 text-center text-sm md:text-base w-full' }
-      - else
-        .text-center.m-5.font-normal.text-base.w-full
-          | カテゴリーがありません。
-    .mt-10.mb-8.text-center.w-full
-      = link_to '+ カテゴリーを登録する', new_category_path, class: 'font-normal py-3 px-5 text-base underline underline-offset-1 md:text-lg text-gray-500 hover:text-gray-900'
+    - if @categories.present?
+      .flex.flex-col.w-full.mx-auto.px-4.justify-center.mb-8.mt-4.text-center
+        = form.label :category_id, '登録済みのカテゴリーから選ぶ', class: 'mt-4 font-normal text-sm md:text-base mb-4'
+        = form.collection_select :category_id, @categories, :id, :name, include_blank: 'カテゴリーなし', class: 'font-normal mt-2 text-center text-sm md:text-base w-full'
+    - else
+      .text-center.m-5.font-normal.text-base.w-full
+        | カテゴリーがありません。
+    .flex.flex-col.w-full.mx-auto.px-4.justify-center.mb-8.mt-4.text-center
+      = form.label :category_id, '新しいカテゴリーを登録する（最大20文字）', class: 'mt-4 font-normal text-sm md:text-base'
+      = form.text_field :new_category_name, placeholder: '例：旅行の思い出', class: 'w-full mt-4 text-base font-normal px-2 text-center md:text-lg'
     .flex.justify-center.mt-10.w-full
       = form.submit '保存する', class: 'bg-sky-300 hover:bg-sky-400 text-white font-bold py-2 px-4 rounded w-full'


### PR DESCRIPTION
## Isuue
- #136 

## 概要
- 思い出登録時に新規カテゴリー登録もできる機能を追加した
  - 思い出とカテゴリーどちらもバリデーションを通過した場合に思い出もカテゴリーも登録される
  - 登録済みのカテゴリーを新規カテゴリー登録フォームに入力した場合は、登録済みのカテゴリーに紐づく（カテゴリーを選択したのと同じ挙動になる）
  - カテゴリーの選択がある状態で、新規カテゴリー登録フォームに入力があった場合は、新規カテゴリーに紐づく（優先度として選択カテゴリー＜入力されたカテゴリー） 