### PR TITLE
カテゴリーを紐づく思い出関連の処理を修正する

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -18,7 +18,7 @@ class CategoriesController < ApplicationController
   def create
     @category = current_user.categories.build(category_params)
     if @category.save
-      redirect_to categories_path, notice: t('notice.create.category')
+      flash.now.notice = t('notice.create.category')
     else
       render :new, status: :unprocessable_entity
     end
@@ -26,7 +26,7 @@ class CategoriesController < ApplicationController
 
   def update
     if @category.update(category_params)
-      redirect_to categories_path, notice: t('notice.update', model: Category.model_name.human)
+      flash.now.notice =  t('notice.update', model: Category.model_name.human)
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -26,7 +26,7 @@ class CategoriesController < ApplicationController
 
   def update
     if @category.update(category_params)
-      flash.now.notice =  t('notice.update', model: Category.model_name.human)
+      flash.now.notice = t('notice.update', model: Category.model_name.human)
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/category_memories_controller.rb
+++ b/app/controllers/category_memories_controller.rb
@@ -6,7 +6,6 @@ class CategoryMemoriesController < ApplicationController
   def index
     @q = @category.memories.ransack(params[:q])
     @q.sorts = 'id desc' if @q.sorts.blank?
-
     @memories = @q.result.page(params[:page]).per(10)
   end
 

--- a/app/controllers/category_memories_controller.rb
+++ b/app/controllers/category_memories_controller.rb
@@ -6,7 +6,7 @@ class CategoryMemoriesController < ApplicationController
   def index
     @q = @category.memories.ransack(params[:q])
     @q.sorts = 'id desc' if @q.sorts.blank?
-    @memories = @q.result.page(params[:page]).per(10)
+    @memories = @q.result.page(params[:page]).per(20)
   end
 
   private

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -22,17 +22,20 @@ class MemoriesController < ApplicationController
   def edit; end
 
   def create
-    @memory = current_user.memories.build(memory_params)
+    memory_attributes = memory_params.except(:new_category_name)
+    @memory = current_user.memories.build(memory_attributes)
+    new_category_created = false
 
     if params[:memory][:new_category_name].present?
-      validate_and_set_category
+      new_category_created = validate_and_set_category
     elsif params[:memory][:category_id].present?
       set_existing_category
     end
 
     if @memory.valid? && valid_category?
       @memory.save
-      display_appropriate_flash_messages
+      @category = @memory.category
+      display_appropriate_flash_messages(new_category_created)
     else
       set_categories
       render :new, status: :unprocessable_entity
@@ -78,13 +81,18 @@ class MemoriesController < ApplicationController
   end
 
   def memory_params
-    params.require(:memory).permit(:content, :category_id)
+    params.require(:memory).permit(:content, :category_id, :new_category_name)
   end
 
   def validate_and_set_category
     @category = current_user.categories.find_or_initialize_by(name: params[:memory][:new_category_name])
-    @category.errors.full_messages.each { |msg| @category_errors << msg } unless @category.valid?
-    @memory.category = @category
+    is_new_record = @category.new_record?
+    if @category.save
+      @memory.category = @category
+    else
+      @category.errors.full_messages.each { |msg| @category_errors << msg }
+    end
+    is_new_record
   end
 
   def set_existing_category
@@ -95,11 +103,37 @@ class MemoriesController < ApplicationController
     @memory.category.nil? || @memory.category&.valid?
   end
 
-  def display_appropriate_flash_messages
-    if request.referer.include?(memories_path)
-      flash.now[:after_create] = t('notice.create.memory')
+  def display_appropriate_flash_messages(new_category_created)
+    if request.referer.include?(categories_path)
+      flash.now[:after_create_with_link] = view_context.link_to('思い出を記録しました。（思い出の一覧を見る）', memories_path)
+      render_create_response(new_category_created)
     else
-      flash.now[:after_create_with_link] = view_context.link_to('思い出を記録しました。（思い出の一覧を見る）', memories_path) unless request.referer.include?(memories_path)
+      flash.now[:after_create] = t('notice.create.memory')
+    end
+  end
+
+  def render_create_response(new_category_created) # 思い出一覧ページ以外にいる時のレンダー処理
+    if new_category_created # 新しいカテゴリーが登録された時、カテゴリー一覧ページに追加される
+      render turbo_stream: [
+        turbo_stream.remove('no-categories-message'), # 思い出経由で1つ目のカテゴリーが登録された時の書き方確認する
+        turbo_stream.prepend('categories', partial: 'categories/category', locals: { category: @category }),
+        turbo_stream.update('flash', partial: 'layouts/flash')
+      ]
+    elsif @memory.category_id.nil? # カテゴリーの紐付けがない思い出はflashだけが表示される
+      render turbo_stream: [
+        turbo_stream.update('flash', partial: 'layouts/flash')
+      ]
+    elsif request.referer.include?(category_memories_path(@memory.category_id)) # 紐づけたカテゴリーの、カテゴリー別思い出一覧ページにいる時
+      render turbo_stream: [
+        turbo_stream.prepend("memories-page-#{@memory.category_id}", partial: 'memory', locals: { memory: @memory }),
+        turbo_stream.update("memories-count-#{@memory.category_id}", partial: 'category_memories/memories-count', locals: { category: @category }),
+        turbo_stream.update('flash', partial: 'layouts/flash')
+      ]
+    else # その他
+      render turbo_stream: [
+        turbo_stream.update("memories-count-#{@memory.category_id}", partial: 'category_memories/memories-count', locals: { category: @category }),
+        turbo_stream.update('flash', partial: 'layouts/flash')
+      ]
     end
   end
 end

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class MemoriesController < ApplicationController
+  include MemoriesHelper
+
   before_action :set_memory, only: %i[edit update destroy]
   before_action :set_categories, only: %i[new create edit update]
   before_action :initialize_category_errors, only: %i[new create edit update]
@@ -27,45 +29,34 @@ class MemoriesController < ApplicationController
 
     if @memory.valid? && valid_category?
       @memory.save
-      determine_flash_messages(new_category_created)
+      determine_flash_messages(@memory, @category, new_category_created)
     else
       set_categories
       render :new, status: :unprocessable_entity
     end
   end
 
-def update
-  old_category_id = @memory.category_id
-  @memory.assign_attributes(memory_params.except(:new_category_name))
- save_category_of_memory
+  def update
+    old_category_id = @memory.category_id
+    @memory.assign_attributes(memory_params.except(:new_category_name))
+    save_category_of_memory
 
-  if @memory.valid? && valid_category?
-    @memory.save
-
-    if old_category_id && old_category_id != @memory.category_id && request_referer(category_memories_path(old_category_id))
-      flash.now.notice = t('notice.update', model: Memory.model_name.human)
-
-      exclude_memory_from_page(old_category_id)
+    if @memory.valid? && valid_category?
+      @memory.save
+      handle_update_flash_and_render(old_category_id)
     else
-      flash.now.notice = t('notice.update', model: Memory.model_name.human)
+      set_categories
+      render :edit, status: :unprocessable_entity
     end
-
-  else
-    set_categories
-    render :edit, status: :unprocessable_entity
   end
-end
 
   def destroy
-    if @memory.category
-      memory_category_id = @memory.category.id
-    end
+    memory_category_id = @memory.category.id if @memory.category
 
     @memory.destroy
     if @memory.category && request_referer(category_memories_path(memory_category_id))
       flash.now[:after_destroy] = t('notice.destroy.memory')
-
-      exclude_memory_from_page(memory_category_id)
+      exclude_memory_from_page(memory_category_id, @memory)
     else
       flash.now[:after_destroy] = t('notice.destroy.memory')
     end
@@ -94,9 +85,7 @@ end
     if params[:memory][:new_category_name].present?
       @category = current_user.categories.find_or_initialize_by(name: params[:memory][:new_category_name])
       new_category_created = @category.new_record?
-      unless @category.save
-        @category.errors.full_messages.each { |msg| @category_errors << msg }
-      end
+      @category.errors.full_messages.each { |msg| @category_errors << msg } unless @category.save
     elsif params[:memory][:category_id].present?
       @category = current_user.categories.find(params[:memory][:category_id])
     end
@@ -108,52 +97,10 @@ end
     @memory.category.nil? || @memory.category&.valid?
   end
 
-  def determine_flash_messages(new_category_created)
-    if request_referer(memories_path)
-      flash.now[:after_create] = t('notice.create.memory')
-    else
-      flash.now[:after_create_with_link] = view_context.link_to('思い出を記録しました。（思い出の一覧を見る）', memories_path)
-      add_memory_to_page(new_category_created)
-    end
-  end
+  def handle_update_flash_and_render(old_category_id)
+    flash.now.notice = t('notice.update', model: Memory.model_name.human)
+    return unless old_category_id && old_category_id != @memory.category_id && request_referer(category_memories_path(old_category_id))
 
-  def add_memory_to_page(new_category_created)
-    if request_referer(categories_path)
-      if new_category_created
-        render turbo_stream: [
-          turbo_stream.remove('no-categories-message'),
-          turbo_stream.prepend('categories', partial: 'categories/category', locals: { category: @category }),
-          turbo_stream.update('flash', partial: 'layouts/flash')
-        ]
-      elsif @memory.category_id
-        render turbo_stream: [
-          turbo_stream.update("memories-count-#{@memory.category_id}", partial: 'category_memories/memories-count', locals: { category: @category }),
-          turbo_stream.update('flash', partial: 'layouts/flash')
-        ]
-      end
-    elsif @memory.category_id && request_referer(category_memories_path(@memory.category_id))
-      render turbo_stream: [
-        turbo_stream.prepend('memories', partial: 'memory', locals: { memory: @memory }),
-        turbo_stream.update("memories-count-#{@memory.category_id}", partial: 'category_memories/memories-count', locals: { category: @category }),
-        turbo_stream.update('flash', partial: 'layouts/flash')
-      ]
-    else
-      render turbo_stream: [
-        turbo_stream.update('flash', partial: 'layouts/flash')
-      ]
-    end
-  end  
-
-  def exclude_memory_from_page(memory_category_id)
-    category = Category.find(memory_category_id)
-    render turbo_stream: [
-      turbo_stream.remove(@memory),
-      turbo_stream.update("memories-count-#{memory_category_id}", partial: 'category_memories/memories-count', locals: { category: category.reload }),
-      turbo_stream.update('flash', partial: 'layouts/flash')
-    ]
-  end
-
-  def request_referer(path)
-    request.referer && URI(request.referer).path == path
+    exclude_memory_from_page(old_category_id, @memory)
   end
 end

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -22,61 +22,50 @@ class MemoriesController < ApplicationController
   def edit; end
 
   def create
-    memory_attributes = memory_params.except(:new_category_name)
-    @memory = current_user.memories.build(memory_attributes)
-    new_category_created = false
-
-    if params[:memory][:new_category_name].present?
-      new_category_created = validate_and_set_category
-    elsif params[:memory][:category_id].present?
-      set_existing_category
-    end
+    @memory = current_user.memories.build(memory_params.except(:new_category_name))
+    new_category_created = save_category_of_memory
 
     if @memory.valid? && valid_category?
       @memory.save
-      @category = @memory.category
-      display_appropriate_flash_messages(new_category_created)
+      determine_flash_messages(new_category_created)
     else
       set_categories
       render :new, status: :unprocessable_entity
     end
   end
 
-  def update
-    old_category_id = @memory.category_id
-    if params[:memory][:new_category_name].present?
-      validate_and_set_category
-    elsif params[:memory][:category_id].present?
-      set_existing_category
-    end
+def update
+  old_category_id = @memory.category_id
+  @memory.assign_attributes(memory_params.except(:new_category_name))
+ save_category_of_memory
 
-    @memory.assign_attributes(memory_params.except(:new_category_name))
-    @memory.category = @category if @category.present?
+  if @memory.valid? && valid_category?
+    @memory.save
 
-    if @memory.valid? && valid_category?
-      @memory.save
+    if old_category_id && old_category_id != @memory.category_id && request_referer(category_memories_path(old_category_id))
+      flash.now.notice = t('notice.update', model: Memory.model_name.human)
 
-      if old_category_id && old_category_id != @memory.category_id && request.referer.include?(category_memories_path(old_category_id))
-        flash.now.notice = t('notice.update', model: Memory.model_name.human)
-
-        render_update_response(old_category_id)
-      else
-        flash.now.notice = t('notice.update', model: Memory.model_name.human)
-      end
-
+      exclude_memory_from_page(old_category_id)
     else
-      set_categories
-      render :edit, status: :unprocessable_entity
+      flash.now.notice = t('notice.update', model: Memory.model_name.human)
     end
+
+  else
+    set_categories
+    render :edit, status: :unprocessable_entity
   end
+end
 
   def destroy
-    memory_category_id = @memory.category.id
+    if @memory.category
+      memory_category_id = @memory.category.id
+    end
+
     @memory.destroy
-    if request.referer.include?(category_memories_path(memory_category_id))
+    if @memory.category && request_referer(category_memories_path(memory_category_id))
       flash.now[:after_destroy] = t('notice.destroy.memory')
 
-      render_destroy_response(memory_category_id)
+      exclude_memory_from_page(memory_category_id)
     else
       flash.now[:after_destroy] = t('notice.destroy.memory')
     end
@@ -100,74 +89,71 @@ class MemoriesController < ApplicationController
     params.require(:memory).permit(:content, :category_id, :new_category_name)
   end
 
-  def validate_and_set_category
-    @category = current_user.categories.find_or_initialize_by(name: params[:memory][:new_category_name])
-    is_new_record = @category.new_record?
-    if @category.save
-      @memory.category = @category
-    else
-      @category.errors.full_messages.each { |msg| @category_errors << msg }
+  def save_category_of_memory
+    new_category_created = false
+    if params[:memory][:new_category_name].present?
+      @category = current_user.categories.find_or_initialize_by(name: params[:memory][:new_category_name])
+      new_category_created = @category.new_record?
+      unless @category.save
+        @category.errors.full_messages.each { |msg| @category_errors << msg }
+      end
+    elsif params[:memory][:category_id].present?
+      @category = current_user.categories.find(params[:memory][:category_id])
     end
-    is_new_record
-  end
-
-  def set_existing_category
-    @memory.category = current_user.categories.find(params[:memory][:category_id])
+    @memory.category = @category if @category
+    new_category_created
   end
 
   def valid_category?
     @memory.category.nil? || @memory.category&.valid?
   end
 
-  def display_appropriate_flash_messages(new_category_created)
-    if request.referer.include?(categories_path)
-      flash.now[:after_create_with_link] = view_context.link_to('思い出を記録しました。（思い出の一覧を見る）', memories_path)
-      render_create_response(new_category_created)
-    else
+  def determine_flash_messages(new_category_created)
+    if request_referer(memories_path)
       flash.now[:after_create] = t('notice.create.memory')
+    else
+      flash.now[:after_create_with_link] = view_context.link_to('思い出を記録しました。（思い出の一覧を見る）', memories_path)
+      add_memory_to_page(new_category_created)
     end
   end
 
-  def render_create_response(new_category_created) # 思い出一覧ページ以外にいる時のレンダー処理
-    if new_category_created # 新しいカテゴリーが登録された時、カテゴリー一覧ページに追加される
+  def add_memory_to_page(new_category_created)
+    if request_referer(categories_path)
+      if new_category_created
+        render turbo_stream: [
+          turbo_stream.remove('no-categories-message'),
+          turbo_stream.prepend('categories', partial: 'categories/category', locals: { category: @category }),
+          turbo_stream.update('flash', partial: 'layouts/flash')
+        ]
+      elsif @memory.category_id
+        render turbo_stream: [
+          turbo_stream.update("memories-count-#{@memory.category_id}", partial: 'category_memories/memories-count', locals: { category: @category }),
+          turbo_stream.update('flash', partial: 'layouts/flash')
+        ]
+      end
+    elsif @memory.category_id && request_referer(category_memories_path(@memory.category_id))
       render turbo_stream: [
-        turbo_stream.remove('no-categories-message'), # 思い出経由で1つ目のカテゴリーが登録された時の書き方確認する
-        turbo_stream.prepend('categories', partial: 'categories/category', locals: { category: @category }),
-        turbo_stream.update('flash', partial: 'layouts/flash')
-      ]
-    elsif @memory.category_id.nil? # カテゴリーの紐付けがない思い出はflashだけが表示される
-      render turbo_stream: [
-        turbo_stream.update('flash', partial: 'layouts/flash')
-      ]
-    elsif request.referer.include?(category_memories_path(@memory.category_id)) # 紐づけたカテゴリーの、カテゴリー別思い出一覧ページにいる時
-      render turbo_stream: [
-        turbo_stream.prepend("memories-page-#{@memory.category_id}", partial: 'memory', locals: { memory: @memory }),
+        turbo_stream.prepend('memories', partial: 'memory', locals: { memory: @memory }),
         turbo_stream.update("memories-count-#{@memory.category_id}", partial: 'category_memories/memories-count', locals: { category: @category }),
         turbo_stream.update('flash', partial: 'layouts/flash')
       ]
-    else # その他
+    else
       render turbo_stream: [
-        turbo_stream.update("memories-count-#{@memory.category_id}", partial: 'category_memories/memories-count', locals: { category: @category }),
         turbo_stream.update('flash', partial: 'layouts/flash')
       ]
     end
-  end
+  end  
 
-  def render_update_response(old_category_id)
-    old_category = Category.find(old_category_id)
-    render turbo_stream: [
-      turbo_stream.remove(@memory), # OK
-      turbo_stream.update("memories-count-#{old_category_id}", partial: 'category_memories/memories-count', locals: { category: old_category.reload }),
-      turbo_stream.update('flash', partial: 'layouts/flash')
-    ]
-  end
-
-  def render_destroy_response(memory_category_id)
+  def exclude_memory_from_page(memory_category_id)
     category = Category.find(memory_category_id)
     render turbo_stream: [
       turbo_stream.remove(@memory),
       turbo_stream.update("memories-count-#{memory_category_id}", partial: 'category_memories/memories-count', locals: { category: category.reload }),
       turbo_stream.update('flash', partial: 'layouts/flash')
     ]
+  end
+
+  def request_referer(path)
+    request.referer && URI(request.referer).path == path
   end
 end

--- a/app/helpers/memories_helper.rb
+++ b/app/helpers/memories_helper.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module MemoriesHelper
+  def determine_flash_messages(memory, category, new_category_created)
+    if request_referer(memories_path)
+      flash.now[:after_create] = t('notice.create.memory')
+    else
+      flash.now[:after_create_with_link] = view_context.link_to('思い出を記録しました。（思い出の一覧を見る）', memories_path)
+      add_memory_to_page(memory, category, new_category_created)
+    end
+  end
+
+  def add_memory_to_page(memory, category, new_category_created)
+    if request_referer(categories_path)
+      render turbo_stream: add_to_category_page(memory, category, new_category_created) + [turbo_stream.update('flash', partial: 'layouts/flash')]
+    elsif memory.category_id && request_referer(category_memories_path(memory.category_id))
+      render turbo_stream: add_to_category_memories_page(memory, category) + [turbo_stream.update('flash', partial: 'layouts/flash')]
+    else
+      render_flash_message
+    end
+  end
+
+  def exclude_memory_from_page(memory_category_id, memory)
+    category = Category.find(memory_category_id)
+    render turbo_stream: [
+      turbo_stream.remove(memory),
+      turbo_stream.update("memories-count-#{memory_category_id}", partial: 'category_memories/memories-count', locals: { category: category.reload }),
+      turbo_stream.update('flash', partial: 'layouts/flash')
+    ]
+  end
+
+  private
+
+  def add_to_category_page(memory, category, new_category_created)
+    if new_category_created
+      [
+        turbo_stream.remove('no-categories-message'),
+        turbo_stream.prepend('categories', partial: 'categories/category', locals: { category: })
+      ]
+    elsif memory.category_id
+      [
+        turbo_stream.update("memories-count-#{memory.category_id}", partial: 'category_memories/memories-count', locals: { category: })
+      ]
+    else
+      []
+    end
+  end
+
+  def add_to_category_memories_page(memory, category)
+    [
+      turbo_stream.prepend('memories', partial: 'memory', locals: { memory: }),
+      turbo_stream.update("memories-count-#{memory.category_id}", partial: 'category_memories/memories-count', locals: { category: })
+    ]
+  end
+
+  def render_flash_message
+    render turbo_stream: [
+      turbo_stream.update('flash', partial: 'layouts/flash')
+    ]
+  end
+
+  def request_referer(path)
+    request.referer && URI(request.referer).path == path
+  end
+end

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -6,7 +6,7 @@ class Memory < ApplicationRecord
 
   validates :content, presence: true, length: { maximum: 400 }
 
-  paginates_per 15
+  paginates_per 20
 
   def self.ransackable_attributes(_auth_object = nil)
     ['id']

--- a/app/views/categories/_category.html.slim
+++ b/app/views/categories/_category.html.slim
@@ -1,9 +1,21 @@
-.w-full.max-w-4xl.mx-auto
-  .flex.flex-wrap.md:flex-nowrap.items-center.justify-center.font-normal.mt-5
-    .w-full.underline.underline-offset-1.text-center.text-base.md:text-lg.mb-4.hover:text-gray-900
-      = link_to "#{category.name}(#{category.memories.count}件)", category_memories_path(category.id), data: { turbo: false }
-  .flex.flex-row.justify-center.items-center.space-y-2.space-y-0.space-x-12.md:space-x-16.text-sm.md:text-base.md:mb-10.mt-6.mb-6
-    = link_to t('activerecord.action.edit'), edit_category_path(category), data: { turbo: false }, class: 'bg-sky-300 hover:bg-sky-500 text-white font-bold py-2 rounded w-36 md:w-44'
-    = button_to t('activerecord.action.destroy.category'),
-      category, method: :delete, data: { turbo_confirm: sanitize("カテゴリー「#{category.name}」を削除しますか？\n紐づけられている#{category.memories.count}件の思い出は「カテゴリー登録なし」になります。") },
-      class: 'bg-gray-400 hover:bg-gray-500 text-white font-bold py-2 w-36 md:w-44 rounded'
+= turbo_frame_tag category do
+  .w-full.max-w-4xl.mx-auto
+    .flex.flex-wrap.md:flex-nowrap.items-center.justify-center.font-normal.mt-5
+      .w-full.underline.underline-offset-1.text-center.text-base.md:text-lg.mb-4.hover:text-gray-900
+        = link_to "カテゴリー: #{category.name} ", category_memories_path(category.id), data: { turbo: false }
+        = turbo_frame_tag "memories-count-#{category.id}" do
+          = category.memories.count
+        | 件
+    .flex.flex-row.justify-center.items-center.space-y-2.space-y-0.space-x-12.md:space-x-16.text-sm.md:text-base.md:mb-10.mt-6.mb-6
+      div data-controller='modal'
+        .flex.flex-row
+          = link_to t('activerecord.action.edit'), edit_category_path(category), data: { turbo_frame: "edit_category_#{category.id}" }, class: 'bg-sky-300 hover:bg-sky-500 text-white font-bold py-2 rounded w-36 md:w-44'
+        .hidden.fixed.top-0.left-0.w-screen.h-screen.bg-blue-300.bg-gray-700/50.max-h-screen data-modal-target='modal' data-action='click->modal#close turbo:frame-load->modal#open turbo:submit-end->modal#close'
+          .absolute.top-1/2.left-1/2.-translate-x-1/2.-translate-y-1/2.bg-white.p-4.rounded-md.w-11/12.md:max-w-lg.md:p-10.overflow-y-scroll.max-h-full data-action="click->modal#stay"
+            .text-right
+              .p.text-3xl.text-gray-500.hover:text-gray-900.cursor-pointer data-action='click->modal#close' type="button"
+                | ×
+              = turbo_frame_tag "edit_category_#{category.id}"
+      = button_to t('activerecord.action.destroy.category'),
+        category, method: :delete, data: { turbo_confirm: sanitize("カテゴリー「#{category.name}」を削除しますか？\n紐づけられている#{category.memories.count}件の思い出は「カテゴリー登録なし」になります。") },
+        class: 'bg-gray-400 hover:bg-gray-500 text-white font-bold py-2 w-36 md:w-44 rounded'

--- a/app/views/categories/_category.html.slim
+++ b/app/views/categories/_category.html.slim
@@ -2,7 +2,7 @@
   .w-full.max-w-4xl.mx-auto
     .flex.flex-wrap.md:flex-nowrap.items-center.justify-center.font-normal.mt-5
       .w-full.text-center.text-base.md:text-lg.mb-4
-        = link_to "#{category.name}", category_memories_path(category.id), class: 'underline underline-offset-1 hover:text-gray-900', data: { turbo: false }
+        = link_to category.name.to_s, category_memories_path(category.id), class: 'underline underline-offset-1 hover:text-gray-900', data: { turbo: false }
         span.inline.no-underline
           | (
           = turbo_frame_tag "memories-count-#{category.id}" do

--- a/app/views/categories/_category.html.slim
+++ b/app/views/categories/_category.html.slim
@@ -18,5 +18,5 @@
                 | ×
               = turbo_frame_tag "edit_category_#{category.id}"
       = button_to t('activerecord.action.destroy.category'),
-        category, method: :delete, data: { turbo_confirm: sanitize("カテゴリー「#{category.name}」を削除しますか？\n紐づけられている#{category.memories.count}件の思い出は「カテゴリー登録なし」になります。") },
+        category, method: :delete, data: { turbo_confirm: sanitize("カテゴリー「#{category.name}」を削除しますか？\n紐づけられている思い出は「カテゴリー登録なし」になります。") },
         class: 'bg-gray-400 hover:bg-gray-500 text-white font-bold py-2 w-36 md:w-44 rounded'

--- a/app/views/categories/_category.html.slim
+++ b/app/views/categories/_category.html.slim
@@ -2,10 +2,11 @@
   .w-full.max-w-4xl.mx-auto
     .flex.flex-wrap.md:flex-nowrap.items-center.justify-center.font-normal.mt-5
       .w-full.underline.underline-offset-1.text-center.text-base.md:text-lg.mb-4.hover:text-gray-900
-        = link_to "カテゴリー: #{category.name} ", category_memories_path(category.id), data: { turbo: false }
+        = link_to "#{category.name} ", category_memories_path(category.id), data: { turbo: false }
+        | (
         = turbo_frame_tag "memories-count-#{category.id}" do
           = category.memories.count
-        | 件
+        | 件)
     .flex.flex-row.justify-center.items-center.space-y-2.space-y-0.space-x-12.md:space-x-16.text-sm.md:text-base.md:mb-10.mt-6.mb-6
       div data-controller='modal'
         .flex.flex-row

--- a/app/views/categories/_category.html.slim
+++ b/app/views/categories/_category.html.slim
@@ -1,12 +1,13 @@
 = turbo_frame_tag category do
   .w-full.max-w-4xl.mx-auto
     .flex.flex-wrap.md:flex-nowrap.items-center.justify-center.font-normal.mt-5
-      .w-full.underline.underline-offset-1.text-center.text-base.md:text-lg.mb-4.hover:text-gray-900
-        = link_to "#{category.name} ", category_memories_path(category.id), data: { turbo: false }
-        | (
-        = turbo_frame_tag "memories-count-#{category.id}" do
-          = category.memories.count
-        | 件)
+      .w-full.text-center.text-base.md:text-lg.mb-4
+        = link_to "#{category.name}", category_memories_path(category.id), class: 'underline underline-offset-1 hover:text-gray-900', data: { turbo: false }
+        span.inline.no-underline
+          | (
+          = turbo_frame_tag "memories-count-#{category.id}" do
+            = category.memories.count
+          | 件)
     .flex.flex-row.justify-center.items-center.space-y-2.space-y-0.space-x-12.md:space-x-16.text-sm.md:text-base.md:mb-10.mt-6.mb-6
       div data-controller='modal'
         .flex.flex-row

--- a/app/views/categories/_category.html.slim
+++ b/app/views/categories/_category.html.slim
@@ -1,0 +1,9 @@
+.w-full.max-w-4xl.mx-auto
+  .flex.flex-wrap.md:flex-nowrap.items-center.justify-center.font-normal.mt-5
+    .w-full.underline.underline-offset-1.text-center.text-base.md:text-lg.mb-4.hover:text-gray-900
+      = link_to "#{category.name}(#{category.memories.count}件)", category_memories_path(category.id), data: { turbo: false }
+  .flex.flex-row.justify-center.items-center.space-y-2.space-y-0.space-x-12.md:space-x-16.text-sm.md:text-base.md:mb-10.mt-6.mb-6
+    = link_to t('activerecord.action.edit'), edit_category_path(category), data: { turbo: false }, class: 'bg-sky-300 hover:bg-sky-500 text-white font-bold py-2 rounded w-36 md:w-44'
+    = button_to t('activerecord.action.destroy.category'),
+      category, method: :delete, data: { turbo_confirm: sanitize("カテゴリー「#{category.name}」を削除しますか？\n紐づけられている#{category.memories.count}件の思い出は「カテゴリー登録なし」になります。") },
+      class: 'bg-gray-400 hover:bg-gray-500 text-white font-bold py-2 w-36 md:w-44 rounded'

--- a/app/views/categories/_form.html.slim
+++ b/app/views/categories/_form.html.slim
@@ -1,18 +1,19 @@
-.text-center.w-full
-  span data-controller="modal"
-    i.fa-regular.fa-circle-question.ml-2.text-gray-500.hover:text-gray-900.cursor-pointer.text-sm.md:text-base.mb-8 data-action="click->modal#open"
-      | カテゴリーについてもっと詳しく見る
-    .hidden.fixed.w-full.h-screen.top-0.left-0.bg-gray-700/50.font-normal data-modal-target="modal" data-action="click->modal#close"
-      .absolute.top-0.md:top-1/2.left-1/2.-translate-x-1/2.md:-translate-y-1/2.bg-white.rounded-md.w-full.md:max-w-md data-action="click->modal#stay"
-        = render 'layouts/category_description'
-  = form_with(model: category, local: true, class: 'w-full') do |form|
-    - if category.errors.any?
-      ul.flex.flex-col.items-center
-        - category.errors.full_messages.each do |message|
-          li.text-red-500.font-normal.text-sm.md:text-base.mb-2.block = message
-    .w-full.max-w-2xl.mx-auto.px-4.justify-center.mb-8
-      = form.text_field :name, class: 'w-full md:w-3/5 text-base font-normal mx-auto px-2 text-center md:text-lg'
-    .flex.justify-center.mt-10.mb-4.text-sm.md:text-base
-      = form.submit '保存する', class: 'bg-sky-300 hover:bg-sky-500 text-white font-bold py-2 rounded w-36 md:w-44'
-    .flex.justify-center.mt-10.mb-4.text-sm.md:text-base
-      = link_to '戻る', categories_path, class: 'text-gray-500 hover:text-gray-900 underline'
+= turbo_frame_tag category do
+  .text-center.w-full
+    span data-controller="modal"
+      i.fa-regular.fa-circle-question.ml-2.text-gray-500.hover:text-gray-900.cursor-pointer.text-sm.md:text-base.mb-8 data-action="click->modal#open"
+        | カテゴリーについてもっと詳しく見る
+      .hidden.fixed.w-full.h-screen.top-0.left-0.bg-gray-700/50.font-normal data-modal-target="modal" data-action="click->modal#close"
+        .absolute.top-0.md:top-1/2.left-1/2.-translate-x-1/2.md:-translate-y-1/2.bg-white.rounded-md.w-full.md:max-w-md data-action="click->modal#stay"
+          = render 'layouts/category_description'
+    = form_with(model: category, local: true, class: 'w-full') do |form|
+      - if category.errors.any?
+        ul.flex.flex-col.items-center
+          - category.errors.full_messages.each do |message|
+            li.text-red-500.font-normal.text-sm.md:text-base.mb-2.block = message
+      .w-full.max-w-2xl.mx-auto.px-4.justify-center.mb-8
+        = form.text_field :name, class: 'w-full md:w-3/5 text-base font-normal mx-auto px-2 text-center md:text-lg'
+      .flex.justify-center.mt-10.mb-4.text-sm.md:text-base
+        = form.submit '保存する', class: 'bg-sky-300 hover:bg-sky-500 text-white font-bold py-2 rounded w-36 md:w-44'
+      .flex.justify-center.mt-10.mb-4.text-sm.md:text-base
+        = link_to '戻る', categories_path, class: 'text-gray-500 hover:text-gray-900 underline'

--- a/app/views/categories/create.turbo_stream.slim
+++ b/app/views/categories/create.turbo_stream.slim
@@ -1,0 +1,3 @@
+= turbo_stream.remove 'no-categories-message'
+= turbo_stream.prepend 'categories', @category
+= turbo_stream.update 'flash', partial: 'layouts/flash'

--- a/app/views/categories/edit.html.slim
+++ b/app/views/categories/edit.html.slim
@@ -1,6 +1,6 @@
-h1.text-2xl.font-bold.text-center.text-gray-600
-  | カテゴリーの編集
+= turbo_frame_tag "edit_category_#{@category.id}" do
   p.text-sm.md:text-base.font-normal.mt-10.mb-2
-    | 以下に変更したいカテゴリー名を入力してください。（最大20文字）
-
+    | 以下に変更したいカテゴリー名を入力してください。
+    br
+    |（最大20文字）
     = render 'form', category: @category

--- a/app/views/categories/index.html.slim
+++ b/app/views/categories/index.html.slim
@@ -19,15 +19,8 @@ h1.text-2xl.font-bold.text-center.text-gray-600.mt-8
     - if @categories.exists?
       - @categories.each do |category|
         = turbo_frame_tag category do
-          .w-full.max-w-4xl.mx-auto
-            .flex.flex-wrap.md:flex-nowrap.items-center.justify-center.font-normal.mt-5
-              .w-full.underline.underline-offset-1.text-center.text-base.md:text-lg.mb-4.hover:text-gray-900
-                = link_to "#{category.name}(#{category.memories.count}件)", category_memories_path(category.id), data: { turbo: false }
-            .flex.flex-row.justify-center.items-center.space-y-2.space-y-0.space-x-12.md:space-x-16.text-sm.md:text-base.md:mb-10.mt-6.mb-6
-              = link_to t('activerecord.action.edit'), edit_category_path(category), data: { turbo: false }, class: 'bg-sky-300 hover:bg-sky-500 text-white font-bold py-2 rounded w-36 md:w-44'
-              = button_to t('activerecord.action.destroy.category'),
-                category, method: :delete, data: { turbo_confirm: sanitize("カテゴリー「#{category.name}」を削除しますか？\n紐づけられている#{category.memories.count}件の思い出は「カテゴリー登録なし」になります。") },
-                class: 'bg-gray-400 hover:bg-gray-500 text-white font-bold py-2 w-36 md:w-44 rounded'
+          = turbo_frame_tag 'categories'
+            = render category
     - else
       .text-center.m-5.font-normal.text-base
         | カテゴリーがまだ登録されていません。

--- a/app/views/categories/index.html.slim
+++ b/app/views/categories/index.html.slim
@@ -10,19 +10,27 @@ h1.text-2xl.font-bold.text-center.text-gray-600.mt-8
         .hidden.fixed.w-full.h-screen.top-0.left-0.bg-gray-700/50 data-modal-target="modal" data-action="click->modal#close"
           .absolute.top-0.md:top-1/2.left-1/2.-translate-x-1/2.md:-translate-y-1/2.bg-white.rounded-md.w-full.md:max-w-md data-action="click->modal#stay"
             = render 'layouts/category_description'
-  .font-normal.text-sm.mb-8
-    = link_to '＋カテゴリーを登録する', new_category_path, class: 'text-lg bg-sky-300 hover:bg-sky-400 text-white font-bold py-3 px-5 rounded'
+  div data-controller='modal'
+    .font-normal.text-sm.mb-8
+      = link_to '＋カテゴリーを登録する', new_category_path, data: { turbo_frame: 'new_category' }, class: 'text-lg bg-sky-300 hover:bg-sky-400 text-white font-bold py-3 px-5 rounded'
+    .hidden.fixed.top-0.left-0.w-screen.h-screen.bg-blue-300.bg-opacity-20.z-50.max-h-screen data-modal-target='modal' data-action='click->modal#close turbo:frame-load->modal#open turbo:submit-end->modal#close'
+      .absolute.top-1/2.left-1/2.-translate-x-1/2.-translate-y-1/2.bg-white.p-4.rounded-md.w-11/12.md:max-w-lg.md:p-10.overflow-y-scroll.max-h-full data-action="click->modal#stay"
+        .text-right
+          button.p.text-3xl.text-gray-500.hover:text-gray-900.cursor-pointer data-action='click->modal#close' type="button"
+            | ×
+        = turbo_frame_tag 'new_category'
 
   .text-base.md:text-lg.font-normal.text-gray-500.mt-6.mb-12.underline.underline-offset-1
     = sort_link(@q, :id, '投稿順')
+
   = turbo_frame_tag "categories-page-#{@categories.current_page}" do
+  = turbo_frame_tag 'categories'
     - if @categories.exists?
       - @categories.each do |category|
         = turbo_frame_tag category do
-          = turbo_frame_tag 'categories'
             = render category
     - else
-      .text-center.m-5.font-normal.text-base
+      .text-center.m-5.font-normal.text-base#no-categories-message
         | カテゴリーがまだ登録されていません。
 
     = turbo_frame_tag "categories-page-#{@categories.next_page}", loading: :lazy, src: path_to_next_page(@categories)

--- a/app/views/categories/index.html.slim
+++ b/app/views/categories/index.html.slim
@@ -23,14 +23,11 @@ h1.text-2xl.font-bold.text-center.text-gray-600.mt-8
   .text-base.md:text-lg.font-normal.text-gray-500.mt-6.mb-12.underline.underline-offset-1
     = sort_link(@q, :id, '投稿順')
 
+  #categories
   = turbo_frame_tag "categories-page-#{@categories.current_page}" do
-  = turbo_frame_tag 'categories'
-    - if @categories.exists?
-      - @categories.each do |category|
-        = turbo_frame_tag category do
-            = render category
-    - else
-      .text-center.m-5.font-normal.text-base#no-categories-message
-        | カテゴリーがまだ登録されていません。
-
+    = render @categories
     = turbo_frame_tag "categories-page-#{@categories.next_page}", loading: :lazy, src: path_to_next_page(@categories)
+
+  - if @categories.empty?
+    .text-center.m-5.font-normal.text-base#no-categories-message
+      | カテゴリーがまだ登録されていません。

--- a/app/views/categories/new.html.slim
+++ b/app/views/categories/new.html.slim
@@ -1,6 +1,6 @@
-h1.text-2xl.font-bold.text-center.text-gray-600
-  | カテゴリーの新規登録
+= turbo_frame_tag 'new_category' do
   p.text-sm.md:text-base.font-normal.mt-10.mb-2
-    | 新しく登録するカテゴリー名を入力してください。（最大20文字）
-
+    | 新しく登録するカテゴリー名を入力してください。
+    br
+    |（最大20文字）
     = render 'form', category: @category

--- a/app/views/categories/update.turbo_stream.slim
+++ b/app/views/categories/update.turbo_stream.slim
@@ -1,0 +1,2 @@
+= turbo_stream.replace @category
+= turbo_stream.update 'flash', partial: 'layouts/flash'

--- a/app/views/category_memories/_memories-count.html.slim
+++ b/app/views/category_memories/_memories-count.html.slim
@@ -1,1 +1,1 @@
-= @memory.category.memories.count
+= category.memories.count

--- a/app/views/category_memories/_memories-count.html.slim
+++ b/app/views/category_memories/_memories-count.html.slim
@@ -1,0 +1,1 @@
+= @memory.category.memories.count

--- a/app/views/category_memories/index.html.slim
+++ b/app/views/category_memories/index.html.slim
@@ -9,22 +9,19 @@ h1.text-base.md:text-2xl.font-bold.text-center.text-gray-600.mt-8
     = sort_link(@q, :id, '投稿順')
   .mb-8
     = button_to t('activerecord.action.destroy.memories_by_category'),
-                destroy_with_memories_category_path(@category), method: :delete, data: { turbo_confirm: sanitize("カテゴリー「#{@category.name}」と、\n紐づく思い出をすべて手放しますか？\n手放した思い出は一覧から削除されます。") },
+                destroy_with_memories_category_path(@category), method: :delete, data: { turbo_confirm: sanitize("カテゴリー「#{@category.name}」と、\n紐づく#{@category.memories.count}件の思い出を手放しますか？\n手放した思い出は一覧から削除されます。") },
                 class: 'text-sm md:text-base bg-gray-400 hover:bg-gray-500 text-white font-bold py-2 rounded'
-
-  = turbo_frame_tag "memories-page-#{@category.id}" do
-  = turbo_frame_tag 'memories'
-    - if @memories.exists?
-      - @memories.each do |memory|
-          = render memory
-    - else
-      .text-center.m-5.font-normal.text-base.md:text-lg
-        | 思い出がまだ登録されていません。
-        br
-        | 画面右下の
-        i.fa-solid.fa-pen-to-square
-        | ボタンをクリックして
-        br
-        | 思い出を登録してみましょう。
-
+  #memories
+  = turbo_frame_tag "memories-page-#{@memories.current_page}"
+    = render @memories
     = turbo_frame_tag "memories-page-#{@memories.next_page}", loading: :lazy, src: path_to_next_page(@memories)
+
+  - if @memories.empty?
+    .text-center.m-5.font-normal.text-base.md:text-lg#no-memories-message
+      | 思い出がまだ登録されていません。
+      br
+      | 画面右下の
+      i.fa-solid.fa-pen-to-square
+      | ボタンをクリックして
+      br
+      | 思い出を登録してみましょう。

--- a/app/views/category_memories/index.html.slim
+++ b/app/views/category_memories/index.html.slim
@@ -16,7 +16,6 @@ h1.text-base.md:text-2xl.font-bold.text-center.text-gray-600.mt-8
   = turbo_frame_tag 'memories'
     - if @memories.exists?
       - @memories.each do |memory|
-          / = turbo_frame_tag 'memories'
           = render memory
     - else
       .text-center.m-5.font-normal.text-base.md:text-lg

--- a/app/views/category_memories/index.html.slim
+++ b/app/views/category_memories/index.html.slim
@@ -2,7 +2,7 @@ h1.text-base.md:text-2xl.font-bold.text-center.text-gray-600.mt-8
   | 「#{@category.name}」
   br
   |の思い出一覧（
-  = turbo_frame_tag "memories-count" do
+  = turbo_frame_tag "memories-count-#{@category.id}" do
     = @category.memories.count
   | 件）
   .text-base.md:text-lg.font-normal.text-gray-500.mt-6.mb-12.underline.underline-offset-1
@@ -12,10 +12,11 @@ h1.text-base.md:text-2xl.font-bold.text-center.text-gray-600.mt-8
                 destroy_with_memories_category_path(@category), method: :delete, data: { turbo_confirm: sanitize("カテゴリー「#{@category.name}」と、\n紐づく#{@category.memories.count}件の思い出を手放しますか？\n手放した思い出は一覧から削除されます。") },
                 class: 'text-sm md:text-base bg-gray-400 hover:bg-gray-500 text-white font-bold py-2 rounded'
 
-  = turbo_frame_tag "memories-page-#{@memories.current_page}" do
+  = turbo_frame_tag "memories-page-#{@category.id}" do
+  = turbo_frame_tag 'memories'
     - if @memories.exists?
       - @memories.each do |memory|
-        = turbo_frame_tag 'memories'
+          / = turbo_frame_tag 'memories'
           = render memory
     - else
       .text-center.m-5.font-normal.text-base.md:text-lg

--- a/app/views/category_memories/index.html.slim
+++ b/app/views/category_memories/index.html.slim
@@ -9,7 +9,7 @@ h1.text-base.md:text-2xl.font-bold.text-center.text-gray-600.mt-8
     = sort_link(@q, :id, '投稿順')
   .mb-8
     = button_to t('activerecord.action.destroy.memories_by_category'),
-                destroy_with_memories_category_path(@category), method: :delete, data: { turbo_confirm: sanitize("カテゴリー「#{@category.name}」と、\n紐づく#{@category.memories.count}件の思い出を手放しますか？\n手放した思い出は一覧から削除されます。") },
+                destroy_with_memories_category_path(@category), method: :delete, data: { turbo_confirm: sanitize("カテゴリー「#{@category.name}」と、\n紐づく思い出をすべて手放しますか？\n手放した思い出は一覧から削除されます。") },
                 class: 'text-sm md:text-base bg-gray-400 hover:bg-gray-500 text-white font-bold py-2 rounded'
 
   = turbo_frame_tag "memories-page-#{@category.id}" do

--- a/app/views/category_memories/index.html.slim
+++ b/app/views/category_memories/index.html.slim
@@ -1,7 +1,10 @@
 h1.text-base.md:text-2xl.font-bold.text-center.text-gray-600.mt-8
   | 「#{@category.name}」
   br
-  |の思い出一覧（#{@category.memories.count}件）
+  |の思い出一覧（
+  = turbo_frame_tag "memories-count" do
+    = @category.memories.count
+  | 件）
   .text-base.md:text-lg.font-normal.text-gray-500.mt-6.mb-12.underline.underline-offset-1
     = sort_link(@q, :id, '投稿順')
   .mb-8

--- a/app/views/category_memories/index.html.slim
+++ b/app/views/category_memories/index.html.slim
@@ -1,35 +1,27 @@
-h1.text-xl.font-bold.text-center.mb-10.mt-8
-  | 「#{@category.name}」カテゴリー
+h1.text-base.md:text-2xl.font-bold.text-center.text-gray-600.mt-8
+  | 「#{@category.name}」
   br
-  |の思い出の一覧（#{@category.memories.count}件）
-  .text-xs.font-normal.text-gray-500.mt-3.mb-8.underline.underline-offset-1.md:text-sm
+  |の思い出一覧（#{@category.memories.count}件）
+  .text-base.md:text-lg.font-normal.text-gray-500.mt-6.mb-12.underline.underline-offset-1
     = sort_link(@q, :id, '投稿順')
-  .mt-3.mb-8
+  .mb-8
     = button_to t('activerecord.action.destroy.memories_by_category'),
                 destroy_with_memories_category_path(@category), method: :delete, data: { turbo_confirm: sanitize("カテゴリー「#{@category.name}」と、\n紐づく#{@category.memories.count}件の思い出を手放しますか？\n手放した思い出は一覧から削除されます。") },
-                class: 'text-xs bg-sky-300 hover:bg-sky-400 text-white font-bold py-2 px-3 rounded md:text-sm'
+                class: 'text-sm md:text-base bg-gray-400 hover:bg-gray-500 text-white font-bold py-2 rounded'
 
-  - if @memories.exists?
-    - @memories.each do |memory|
-      .w-full.max-w-2xl.mx-auto.px-2.font-normal.md:px-24
-        .flex.flex-col.items-center.justify-center.text-left.text-sm.md:text-base.mt-5
-          p.mb-6
-            | #{memory.content}
-            - if memory.category
-              br
-              p.text-xs.text-gray-500.underline.underline-offset-1.mb-6.md:text-sm
-                = link_to "カテゴリー: #{memory.category.name}", category_memories_path(memory.category.id)
-          .flex.flex-col.md:flex-row.justify-center.items-center.space-y-2.md:space-y-0.md:space-x-6.text-xs.md:text-sm
-            p.text-xs.text-normal.md:text-sm
-              | 投稿日: #{l(memory.created_at, format: :date_only)}
-            .flex.flex-row.space-x-2
-              = button_to t('activerecord.action.edit'), edit_memory_path(memory), method: :get, class: 'bg-sky-300 hover:bg-sky-400 text-white font-bold py-2 px-3 rounded'
-              = button_to t('activerecord.action.destroy.memory'),
-                memory, method: :delete, data: { turbo_confirm: sanitize("この思い出を手放しますか？\n手放した思い出は一覧から削除されます。") }, class: 'bg-sky-300 hover:bg-sky-400 text-white font-bold py-2 px-3 rounded'
-  - else
-    .text-center.m-5.font-normal.text-base
-      | 思い出がまだ登録されていません。
-      br
-      | 画面右下の✏️ボタンをクリックし、思い出を登録してみましょう。
+  = turbo_frame_tag "memories-page-#{@memories.current_page}" do
+    - if @memories.exists?
+      - @memories.each do |memory|
+        = turbo_frame_tag 'memories'
+          = render memory
+    - else
+      .text-center.m-5.font-normal.text-base.md:text-lg
+        | 思い出がまだ登録されていません。
+        br
+        | 画面右下の
+        i.fa-solid.fa-pen-to-square
+        | ボタンをクリックして
+        br
+        | 思い出を登録してみましょう。
 
-  = paginate @memories
+    = turbo_frame_tag "memories-page-#{@memories.next_page}", loading: :lazy, src: path_to_next_page(@memories)

--- a/app/views/memories/create.turbo_stream.slim
+++ b/app/views/memories/create.turbo_stream.slim
@@ -1,4 +1,3 @@
+= turbo_stream.remove 'no-memories-message'
 = turbo_stream.prepend 'memories', @memory
 = turbo_stream.update 'flash', partial: 'layouts/flash'
-= turbo_stream.update 'memories-count', partial: 'category_memories/memories-count'
-= turbo_stream.replace @category

--- a/app/views/memories/create.turbo_stream.slim
+++ b/app/views/memories/create.turbo_stream.slim
@@ -1,2 +1,3 @@
 = turbo_stream.prepend 'memories', @memory
 = turbo_stream.update 'flash', partial: 'layouts/flash'
+= turbo_stream.update 'memories-count', partial: 'category_memories/memories-count'

--- a/app/views/memories/create.turbo_stream.slim
+++ b/app/views/memories/create.turbo_stream.slim
@@ -1,3 +1,4 @@
 = turbo_stream.prepend 'memories', @memory
 = turbo_stream.update 'flash', partial: 'layouts/flash'
 = turbo_stream.update 'memories-count', partial: 'category_memories/memories-count'
+= turbo_stream.replace @category

--- a/app/views/memories/index.html.slim
+++ b/app/views/memories/index.html.slim
@@ -4,19 +4,17 @@ h1.text-2xl.font-bold.text-center.text-gray-600.mt-8
   .text-base.md:text-lg.font-normal.text-gray-500.mt-6.mb-12.underline.underline-offset-1
     = sort_link(@q, :id, '投稿順')
 
-  = turbo_frame_tag "memories-page-#{@memories.current_page}" do
-  = turbo_frame_tag 'memories'
-    - if @memories.exists?
-      - @memories.each do |memory|
-          = render memory
-    - else
-      .text-center.m-5.font-normal.text-base.md:text-lg#no-memories-message
-        | 思い出がまだ登録されていません。
-        br
-        | 画面右下の
-        i.fa-solid.fa-pen-to-square
-        | ボタンをクリックして
-        br
-        | 思い出を登録してみましょう。
+  #memories
+    = turbo_frame_tag "memories-page-#{@memories.current_page}"
+      = render @memories
+      = turbo_frame_tag "memories-page-#{@memories.next_page}", loading: :lazy, src: path_to_next_page(@memories)
 
-    = turbo_frame_tag "memories-page-#{@memories.next_page}", loading: :lazy, src: path_to_next_page(@memories)
+  - if @memories.empty?
+    .text-center.m-5.font-normal.text-base.md:text-lg#no-memories-message
+      | 思い出がまだ登録されていません。
+      br
+      | 画面右下の
+      i.fa-solid.fa-pen-to-square
+      | ボタンをクリックして
+      br
+      | 思い出を登録してみましょう。

--- a/app/views/memories/index.html.slim
+++ b/app/views/memories/index.html.slim
@@ -5,12 +5,12 @@ h1.text-2xl.font-bold.text-center.text-gray-600.mt-8
     = sort_link(@q, :id, '投稿順')
 
   = turbo_frame_tag "memories-page-#{@memories.current_page}" do
+  = turbo_frame_tag 'memories'
     - if @memories.exists?
       - @memories.each do |memory|
-        = turbo_frame_tag 'memories'
           = render memory
     - else
-      .text-center.m-5.font-normal.text-base.md:text-lg
+      .text-center.m-5.font-normal.text-base.md:text-lg#no-memories-message
         | 思い出がまだ登録されていません。
         br
         | 画面右下の

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -28,7 +28,7 @@ ja:
       destroy:
         category: 削除する
         memory: 手放す（削除する）
-        memories_by_category: "このカテゴリーの思い出をまとめて手放す（削除する）"
+        memories_by_category: "カテゴリーと、紐づく思い出を全て手放す（削除する）"
 
   notice:
     create:


### PR DESCRIPTION
## Issue
- #42 
- #125 

## 概要
- カテゴリー別思い出一覧ページのレイアウトを修正
- 以下をTurbo化
  - カテゴリー別の思い出件数
  - カテゴリーのCRUD機能をTurbo化
  - ページネーションの修正
  - 思い出のCRUD操作に関連するビューの更新ロジックをhelperに切り出し