### PR TITLE
アカウント設定ページの調整

### DIFF
--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -1,4 +1,4 @@
-h1.text-xl.font-bold.text-center.mb-8.mt-8
+h2.text-xl.font-bold.text-center.mb-6
   = t('.title', resource: devise_i18n_fix_model_name_case(resource.model_name.human, i18n_key: 'registrations.edit.title'))
 
 .text-center
@@ -7,55 +7,54 @@ h1.text-xl.font-bold.text-center.mb-8.mt-8
 
     h3.font-bold.text-lg
       | メールアドレス（必須）
-
-    .field.mb-8.flex.flex-col.items-center.mt-2
-      .w-full.flex.justify-center
-        .w-full.max-w-lg.text-left
-          = f.label :email, class: 'text-base font-normal mb-2'
-          br
-          = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'w-full text-sm font-normal text-left sm:text-base mb-2'
-          - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-            div
-              = t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email)
+      .text-center
+        .field.mb-6.mt-4
+          .w-full
+            .max-w-sm.mx-auto.text-left.font-normal
+              = f.label :email, class: 'text-base sm:text-lg font-normal mb-2'
+              = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'font-nomal w-full text-base sm:text-lg mb-2 rounded'
+              - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+                div
+                  = t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email)
 
     h3.font-bold.text-lg
       | パスワード変更
-      .font-normal.text-sm.mb-4
+      .font-normal.text-sm.sm:text-base
         = t('.leave_blank_if_you_don_t_want_to_change_it')
-    .field.mb-6.flex.flex-col.items-center
-      .w-full.flex.justify-center
-        .w-full.max-w-lg.text-left
-          = f.label :password, class: 'text-base font-normal mb-2'
-          - if @minimum_password_length
-            = t('devise.shared.minimum_password_length', count: @minimum_password_length)
-          br
-          = f.password_field :password, autocomplete: 'new-password', class: 'w-full text-sm font-normal text-left sm:text-base mb-2'
-    .field.mb-8.flex.flex-col.items-center
-      .w-full.flex.justify-center
-        .w-full.max-w-lg.text-left
-          = f.label :password_confirmation, class: 'text-base font-normal mb-2'
-          br
-          = f.password_field :password_confirmation, autocomplete: 'new-password', class: 'w-full text-sm font-normal text-left sm:text-base mb-2'
+      .text-center
+        .field.mb-6.mt-4
+          .w-full
+            .max-w-sm.mx-auto.text-left.font-normal
+              = f.label :password, class: 'text-base sm:text-lg font-normal mb-2'
+              - if @minimum_password_length
+                = t('devise.shared.minimum_password_length', count: @minimum_password_length)
+              = f.password_field :password, autocomplete: 'new-password', class: 'w-full text-base sm:text-lg mb-2 rounded'
+      .text-center
+        .field.mb-6.mt-4
+          .w-full
+            .max-w-sm.mx-auto.text-left.font-normal
+              = f.label :password_confirmation, class: 'text-base sm:text-lg font-normal mb-2'
+              br
+              = f.password_field :password_confirmation, autocomplete: 'new-password', class: 'w-full text-base sm:text-lg mb-2 rounded'
 
     h3.font-bold.text-lg
       | 現在のパスワードを入力
-
-      .font-normal.text-sm.mb-4
-        = t('.we_need_your_current_password_to_confirm_your_changes')
-    .field.mb-6.flex.flex-col.items-center
-      .w-full.flex.justify-center
-        .w-full.max-w-lg.text-left
-          = f.label :current_password, class: 'text-base font-normal mb-2'
-          br
-          = f.password_field :current_password, autocomplete: 'current-password', class: 'w-full text-sm font-normal text-left sm:text-base mb-8'
-      .actions
-        = f.submit t('.update'), class: 'bg-sky-300 hover:bg-sky-400 text-white font-bold py-2 px-4 rounded mb-4'
-    = button_to t('.cancel_my_account'),
-                registration_path(resource_name),
-                data: { confirm: t('.are_you_sure'),
-                turbo_confirm: t('.are_you_sure') },
-                method: :delete,
-                class: 'text-base text-gray-700 hover:text-gray-500'
+      .font-normal.text-sm.sm:text-base
+        = raw t('.we_need_your_current_password_to_confirm_your_changes')
+      .text-center
+        .field.mb-6.mt-4
+          .w-full
+            .max-w-sm.mx-auto.text-left.font-normal
+              = f.label :current_password, class: 'text-base sm:text-lg font-normal mb-2'
+              = f.password_field :current_password, autocomplete: 'current-password', class: 'w-full text-base sm:text-lg mb-2 rounded'
+      .text-center
+        = f.submit t('.update'), class: 'block bg-sky-400 hover:bg-sky-300 text-white font-bold py-3 px-8 rounded mx-auto text-base sm:text-lg w-52 mb-8'
+  = button_to t('.cancel_my_account'),
+              registration_path(resource_name),
+              data: { confirm: t('.are_you_sure'),
+              turbo_confirm: t('.are_you_sure') },
+              method: :delete,
+              class: 'text-base underline hover:no-underline text-gray-700 hover:text-gray-500 mb-6'
   = link_to t('devise.shared.links.back'),
             :back,
-            class: 'text-base text-gray-700 hover:text-gray-500'
+            class: 'text-base underline hover:no-underline text-gray-700 hover:text-gray-500'

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -97,10 +97,10 @@ ja:
         cancel_my_account: アカウントを削除する
         currently_waiting_confirmation_for_email: "%{email} の確認待ち"
         leave_blank_if_you_don_t_want_to_change_it: パスワードを変更しない場合、入力は不要です。
-        title: "%{resource}設定"
+        title: "アカウント設定"
         unhappy: 気に入りません
         update: 更新
-        we_need_your_current_password_to_confirm_your_changes: メールアドレスまたはパスワードを変更するために、現在のパスワードを入力してください。
+        we_need_your_current_password_to_confirm_your_changes: "メールアドレスまたはパスワードを変更するために、<br>現在のパスワードを入力してください。"
       new:
         sign_up: アカウント登録
       signed_up: アカウント登録が完了しました。


### PR DESCRIPTION
## Issue
- #55 
- #59 

## 概要
- アカウント設定ページのレイアウト調整
- 退会時にメールアドレスとパスワード入力を求められるバグを修正