### PR TITLE
ランダムページでリロード前に1つ目の思い出を更新した際に「もっと見る」ボタンが消えないように修正

### DIFF
--- a/app/views/memories/_memory_with_more_link.html.slim
+++ b/app/views/memories/_memory_with_more_link.html.slim
@@ -1,5 +1,5 @@
 = turbo_frame_tag memory do
   = render @memory
 
-  .flex.justify-center.items-center.my-10
-    = link_to 'もっと見る', root_path, data: { turbo: false }, class: 'block relative bg-white hover:bg-sky-100 text-sky-400 border-sky-400 border-2 font-bold rounded py-3 px-8 text-center mx-auto text-lg w-52 z-20'
+.flex.justify-center.items-center.my-10
+  = link_to 'もっと見る', root_path, data: { turbo: false }, class: 'block relative bg-white hover:bg-sky-100 text-sky-400 border-sky-400 border-2 font-bold rounded py-3 px-8 text-center mx-auto text-lg w-52 z-20'


### PR DESCRIPTION
## Issue
- #243 

## 概要
- ランダムページでリロード前に1つ目の思い出を更新した際に「もっと見る」ボタンが消えるバグを修正した