### PR TITLE
使用されなくなったdestroy-btnを削除

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -11,10 +11,6 @@
     @apply bg-sky-400 hover:bg-sky-300 text-white font-bold rounded py-2 w-36 sm:w-44;
   }
 
-  .destroy-btn {
-    @apply bg-gray-400 hover:bg-gray-300 text-white font-bold rounded py-2 w-36 sm:w-44;
-  }
-
   .link {
     @apply text-gray-700 hover:text-gray-500;
   }


### PR DESCRIPTION
## Issue
- #245 

## 概要
使用されなくなったdestroy-btnをstylesheets/application.tailwind.cssから削除