### PR TITLE
destroy_with_memoriesアクションをdestroyに含めるように修正

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CategoriesController < ApplicationController
-  before_action :set_category, only: %i[edit update destroy destroy_with_memories]
+  before_action :set_category, only: %i[edit update destroy]
 
   def index
     @q = current_user.categories.ransack(params[:q])
@@ -33,15 +33,15 @@ class CategoriesController < ApplicationController
   end
 
   def destroy
-    @category.destroy
-    @category_count = current_user.categories.count
-    flash.now.notice = t('notice.destroy.category')
-  end
-
-  def destroy_with_memories
-    @category.memories.destroy_all
-    @category.destroy
-    redirect_to memories_path, notice: t('notice.destroy.category_with_memories')
+    if params[:with_memories] == 'true'
+      @category.memories.destroy_all
+      @category.destroy
+      redirect_to memories_path, notice: t('notice.destroy.category_with_memories')
+    else
+      @category.destroy
+      @category_count = current_user.categories.count
+      flash.now.notice = t('notice.destroy.category')
+    end
   end
 
   private

--- a/app/views/category_memories/index.html.slim
+++ b/app/views/category_memories/index.html.slim
@@ -10,7 +10,7 @@
 
   .flex.flex-col
     = link_to t('activerecord.action.destroy.memories_by_category'),
-      destroy_with_memories_category_path(@category), method: :delete, data: { turbo_method: :delete, turbo_confirm: sanitize("カテゴリー「#{@category.name}」と、\n紐づく思い出をすべて手放しますか？\n手放した思い出は一覧から削除されます。") },
+      category_path(@category, with_memories: true), method: :delete, data: { turbo_method: :delete, turbo_confirm: sanitize("カテゴリー「#{@category.name}」と、\n紐づく思い出をすべて手放しますか？\n手放した思い出は一覧から削除されます。") },
       class: 'link-with-underline font-normal text-sm sm:text-base justify-start my-2'
     .flex.justify-end.text-base.sm:text-lg.link-with-underline.mb-2
       = sort_link(@q, :id, '投稿順')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,6 @@ Rails.application.routes.draw do
 
   resources :categories, expect: [:show] do
     resources :memories, only: [:index], controller: 'category_memories'
-    member do
-      delete :destroy_with_memories
-    end
   end
 
   resources :memories, except: [:show]

--- a/spec/system/categories_spec.rb
+++ b/spec/system/categories_spec.rb
@@ -72,30 +72,32 @@ RSpec.describe 'Memories', type: :system do
   end
 
   describe '#destroy' do
-    it 'カテゴリーが削除できる' do
-      create(:category, user: confirm_user)
-      visit categories_path
-      click_link '編集する'
-      click_link 'このカテゴリーを削除する'
-      expect(page.accept_confirm).to eq "カテゴリー「嬉しかったこと」を削除しますか？\n紐づけられている思い出は「カテゴリー登録なし」になります。"
-      expect(page).to have_content 'カテゴリーを削除しました'
-      expect(page).not_to have_content '嬉しかったこと'
+    context 'params[:with_memories]が true の場合' do
+      it 'カテゴリーと紐づく思い出を削除できる' do
+        category = create(:category, user: confirm_user)
+        create(:memory, content: 'カテゴリーと削除する思い出', user: confirm_user, category:)
+        visit category_memories_path(category.id)
+        click_link 'このカテゴリーと、紐づく思い出を全て手放す（削除する）'
+        expect(page.accept_confirm).to eq "カテゴリー「嬉しかったこと」と、\n紐づく思い出をすべて手放しますか？\n手放した思い出は一覧から削除されます。"
+        expect(page).to have_content 'カテゴリーと、カテゴリーに紐づく思い出一覧を手放しました。'
+        expect(current_path).to eq(memories_path)
+        expect(page).not_to have_content 'カテゴリーと削除する思い出'
+
+        visit categories_path
+        expect(page).not_to have_content '嬉しかったこと'
+      end
     end
-  end
 
-  describe '#destroy_with_memories' do
-    it 'カテゴリーと紐づく思い出を削除できる' do
-      category = create(:category, user: confirm_user)
-      create(:memory, content: 'カテゴリーと削除する思い出', user: confirm_user, category:)
-      visit category_memories_path(category.id)
-      click_link 'このカテゴリーと、紐づく思い出を全て手放す（削除する）'
-      expect(page.accept_confirm).to eq "カテゴリー「嬉しかったこと」と、\n紐づく思い出をすべて手放しますか？\n手放した思い出は一覧から削除されます。"
-      expect(page).to have_content 'カテゴリーと、カテゴリーに紐づく思い出一覧を手放しました。'
-      expect(current_path).to eq(memories_path)
-      expect(page).not_to have_content 'カテゴリーと削除する思い出'
-
-      visit categories_path
-      expect(page).not_to have_content '嬉しかったこと'
+    context 'params[:with_memories]が存在しないか false の場合' do
+      it 'カテゴリーが削除できる' do
+        create(:category, user: confirm_user)
+        visit categories_path
+        click_link '編集する'
+        click_link 'このカテゴリーを削除する'
+        expect(page.accept_confirm).to eq "カテゴリー「嬉しかったこと」を削除しますか？\n紐づけられている思い出は「カテゴリー登録なし」になります。"
+        expect(page).to have_content 'カテゴリーを削除しました'
+        expect(page).not_to have_content '嬉しかったこと'
+      end
     end
   end
 end


### PR DESCRIPTION
## Issue
- #270 

## 概要
- destroy_with_memoriesアクションをdestroyに含めるように修正