### PR TITLE
ログイン後トップページの不具合解消

### DIFF
--- a/app/helpers/memories_helper.rb
+++ b/app/helpers/memories_helper.rb
@@ -36,7 +36,7 @@ module MemoriesHelper
 
     if referer_matches_path?(authenticated_root_path)
       turbo_streams += [
-        turbo_stream.replace('first-memory', partial: 'memories/random/memory_with_more_link', locals: { memory: }),
+        turbo_stream.replace('memories', partial: 'memories/random/memory_with_more_link', locals: { memory: }),
         turbo_stream.remove('no-memories-message')
       ]
     elsif memory.category_id && referer_matches_path?(category_memories_path(memory.category_id))

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -2,6 +2,7 @@ doctype html
 html.bg-slate-200
   head
     meta[name="viewport" content="width=device-width,initial-scale=1"]
+    meta[name="turbo-cache-control" content="no-cache"]
     = csrf_meta_tags
     = csp_meta_tag
     = display_meta_tags(default_meta_tags)

--- a/app/views/memories/random/show.html.slim
+++ b/app/views/memories/random/show.html.slim
@@ -24,7 +24,6 @@
                 | 画面右下の
                 i.fa-solid.fa-pen-to-square
                 | をクリックして思い出を登録してみましょう。
-            #first-memory
 
           - if @memory
             = turbo_frame_tag 'random_memory' do


### PR DESCRIPTION
## Issue
- #293 
- #294 

## 概要
以下の不具合を修正
- 「もっと見る」の表示不具合
- 思い出が0件になった後、新たに登録しても表示されない