### PR TITLE
削除後のカウント方法を修正する

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -39,7 +39,6 @@ class CategoriesController < ApplicationController
       redirect_to memories_path, notice: t('notice.destroy.category_with_memories')
     else
       @category.destroy
-      @category_count = current_user.categories.count
       set_flash_message(:notice, t('notice.destroy.category'))
     end
   end

--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -67,7 +67,6 @@ class MemoriesController < ApplicationController
     memory_category_id = @memory.category&.id
 
     @memory.destroy
-    @memories_count = current_user.memories.count
     flash.now[:after_destroy] = t('notice.destroy.memory')
 
     return unless memory_category_id && referer_matches_path?(category_memories_path(memory_category_id))

--- a/app/views/categories/destroy.turbo_stream.slim
+++ b/app/views/categories/destroy.turbo_stream.slim
@@ -1,4 +1,4 @@
 = turbo_stream.remove @category
 = turbo_stream.update 'flash', partial: 'shared/flash'
-- if @category_count&.zero?
+- unless current_user.categories.exists?
   = turbo_stream.update 'categories', partial: 'no_categories_message'

--- a/app/views/memories/destroy.turbo_stream.slim
+++ b/app/views/memories/destroy.turbo_stream.slim
@@ -1,4 +1,4 @@
 = turbo_stream.remove @memory
 = turbo_stream.update 'flash', partial: 'shared/flash'
-- if @memories_count&.zero?
+- unless current_user.memories.exists?
   = turbo_stream.update 'memories', partial: 'no_memories_message'


### PR DESCRIPTION
## Issue
- #302 

## 概要
思い出、カテゴリー削除後の件数カウントをdestroy.turbo_stream.slimで行うように修正