### PR TITLE
Memory登録時のCategoryエラーをActiveRecordを使用するように修正

### DIFF
--- a/app/controllers/memories_controller.rb
+++ b/app/controllers/memories_controller.rb
@@ -5,7 +5,6 @@ class MemoriesController < ApplicationController
 
   before_action :set_memory, only: %i[edit update destroy]
   before_action :set_categories, only: %i[new create edit update]
-  before_action :initialize_category_errors, only: %i[new create edit update]
 
   def index
     @query = current_user.memories.ransack(params[:q])
@@ -25,7 +24,7 @@ class MemoriesController < ApplicationController
     ActiveRecord::Base.transaction do
       @memory = current_user.memories.build(memory_params.except(:new_category_name))
 
-      @category, @category_errors = @memory.assign_category(memory_params, current_user)
+      @category = @memory.assign_category(memory_params, current_user)
 
       raise ActiveRecord::Rollback unless @memory.valid? && @memory.valid_category?
 
@@ -47,7 +46,7 @@ class MemoriesController < ApplicationController
     ActiveRecord::Base.transaction do
       @memory.assign_attributes(memory_params.except(:new_category_name))
 
-      @category, @category_errors = @memory.assign_category(memory_params, current_user)
+      @category = @memory.assign_category(memory_params, current_user)
 
       raise ActiveRecord::Rollback unless @memory.valid? && @memory.valid_category?
 
@@ -83,10 +82,6 @@ class MemoriesController < ApplicationController
 
   def set_categories
     @categories = current_user.categories.all
-  end
-
-  def initialize_category_errors
-    @category_errors = []
   end
 
   def memory_params

--- a/app/models/memory.rb
+++ b/app/models/memory.rb
@@ -17,21 +17,13 @@ class Memory < ApplicationRecord
   end
 
   def assign_category(params, user)
-    category_errors = []
-
     if params[:new_category_name].present?
       category = user.categories.find_or_initialize_by(name: params[:new_category_name])
-
-      unless category.valid?
-        category.errors.full_messages.each do |message|
-          category_errors << message
-        end
-      end
+      category.valid?
     elsif params[:category_id].present?
       category = user.categories.find(params[:category_id])
     end
-
     self.category = category if category
-    [category, category_errors]
+    category
   end
 end

--- a/app/views/memories/_form.html.slim
+++ b/app/views/memories/_form.html.slim
@@ -1,7 +1,7 @@
 - placeholder_text = "例：一時帰国中の●●と会った。\n相変わらず元気でパワフルで、たくさんの刺激をもらった！目標に向かって頑張る人はかっこいい！\n私も何かチャレンジしたい気持ちになった。キックボクシングの体験教室行ってみようかな〜"
 = form_with(model: memory, class: 'w-full', data: { controller: 'character-counter' }) do |form|
   = render 'shared/error_messages', errors: @memory.errors.full_messages if @memory.errors.any?
-  = render 'shared/error_messages', errors: @category_errors if @category_errors.any?
+  = render 'shared/error_messages', errors: @category.errors.full_messages if @category&.errors&.any?
   .sm:px-6
   .flex.flex-col.w-full.mx-auto.mb-4.sm:mb-6.text-center.gap-2
     h2.text-base.sm:text-lg

--- a/spec/models/memory_spec.rb
+++ b/spec/models/memory_spec.rb
@@ -41,39 +41,35 @@ RSpec.describe Memory, type: :model do
       it 'カテゴリーが作成され、思い出に紐づけられる' do
         memory = build(:memory, user: confirm_user)
 
-        category, category_errors = memory.assign_category({ new_category_name: '新しいカテゴリー' }, confirm_user)
+        category = memory.assign_category({ new_category_name: '新しいカテゴリー' }, confirm_user)
 
         expect(category.name).to eq('新しいカテゴリー')
         expect(memory.category).to eq(category)
-        expect(category_errors).to be_empty
       end
 
       it 'カテゴリーが invalid の場合、エラーが返される' do
         memory = build(:memory, user: confirm_user)
-        _category, category_errors = memory.assign_category({ new_category_name: 'x' * 20 }, confirm_user)
+        category = memory.assign_category({ new_category_name: 'x' * 20 }, confirm_user)
 
-        expect(category_errors).not_to be_empty
-        expect(category_errors).to include('カテゴリー名は15文字以内で入力してください')
+        expect(category.errors.full_messages).to include('カテゴリー名は15文字以内で入力してください')
       end
     end
 
     context '登録済みのカテゴリーIDが渡された場合' do
       it '登録済みのカテゴリーが思い出に紐づけられる' do
         memory = build(:memory, user: confirm_user)
-        _category, category_errors = memory.assign_category({ category_id: valid_category.id }, confirm_user)
+        _category = memory.assign_category({ category_id: valid_category.id }, confirm_user)
 
         expect(memory.category).to eq(valid_category)
-        expect(category_errors).to be_empty
       end
     end
 
     context '新しいカテゴリー名も登録済みのカテゴリーIDも渡されない場合' do
       it 'カテゴリーは思い出に紐づけられない' do
         memory = build(:memory, user: confirm_user)
-        _category, category_errors = memory.assign_category({}, confirm_user)
+        _category = memory.assign_category({}, confirm_user)
 
         expect(memory.category).to be_nil
-        expect(category_errors).to be_empty
       end
     end
   end


### PR DESCRIPTION
## Issue
- #304 

## 概要
- Memory登録時のCategoryエラーをActiveRecordを使用するように修正