### PR TITLE
トップページの favicon を変更

### DIFF
--- a/app/views/memories/random/show.html.slim
+++ b/app/views/memories/random/show.html.slim
@@ -22,7 +22,7 @@
                 | 登録すると、ここにランダムで過去の思い出が表示されます。
               p
                 | 画面右下の
-                i.fa-solid.fa-pen-to-square
+                i.fa-solid.fa-plus
                 | をクリックして思い出を登録してみましょう。
 
           - if @memory


### PR DESCRIPTION
トップページの favicon がクリックするボタンと違うものになっていていたので、思い出一覧ページと同じ favicon に変更しました(意図的なものだったらクローズしてください🙏)

|before|after|
| --- | --- |
|![SCR-20241116-iyic](https://github.com/user-attachments/assets/038dcbc1-ed51-4c61-9f48-fe1622b74285)  | ![SCR-20241116-iylg](https://github.com/user-attachments/assets/f2fd8578-6bd1-4ee1-b995-170a9c12a7ef) |


